### PR TITLE
upgrade calcit-0.7 ; make use of tag-match

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,25 +10,21 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: ACTIONS_ALLOW_UNSECURE_COMMANDS
-      id: ACTIONS_ALLOW_UNSECURE_COMMANDS
-      run: echo 'ACTIONS_ALLOW_UNSECURE_COMMANDS=true' >> $GITHUB_ENV
+    - uses: supplypike/setup-bin@v3
+      with:
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a3/cr'
+        name: 'cr'
+        version: '0.7.0-a3'
 
-    - name: add cr
-      run: |
-        mkdir -p $GITHUB_WORKSPACE/bin
-        wget -O $GITHUB_WORKSPACE/bin/cr https://github.com/calcit-lang/calcit/releases/download/0.6.2/cr
-        chmod +x $GITHUB_WORKSPACE/bin/cr
-        echo "::add-path::$GITHUB_WORKSPACE/bin"
-
-    - name: "prepare modules"
-      run: >
-        mkdir -p ~/.config/calcit/modules/ && cd ~/.config/calcit/modules/
-        && git clone https://github.com/calcit-lang/calcit-test.git
+    - uses: supplypike/setup-bin@v3
+      with:
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a3/caps'
+        name: 'caps'
+        version: '0.7.0-a3'
 
     - name: "test"
-      run: mode=ci cr -1
+      run: caps --ci && mode=ci cr -1
 
     - run: mode=ci cr --emit-js -1 && yarn && mode=ci node ./main.mjs

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,15 +14,15 @@ jobs:
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a3/cr'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a5/cr'
         name: 'cr'
-        version: '0.7.0-a3'
+        version: '0.7.0-a5'
 
     - uses: supplypike/setup-bin@v3
       with:
-        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a3/caps'
+        uri: 'https://github.com/calcit-lang/calcit/releases/download/0.7.0-a5/caps'
         name: 'caps'
-        version: '0.7.0-a3'
+        version: '0.7.0-a5'
 
     - name: "test"
       run: caps --ci && mode=ci cr -1

--- a/README.md
+++ b/README.md
@@ -9,55 +9,62 @@
 Maybe:
 
 ```cirru
-ns demo
-  :require
-    algebra.maybe :refer $ maybe-class
+; |map
 
-is $ = (:: maybe-class nil)
-  .map (:: maybe-class nil) inc
-is $ = (:: maybe-class 2)
-  .map (:: maybe-class 1) inc
+is $ = (%maybe :none)
+  .map (%maybe :none) inc
 
-is $ = (:: maybe-class 2)
-  .bind (:: maybe-class 1)
+is $ = (%maybe :some 2)
+  .map (%maybe :some 1) inc
+
+; "\"bind"
+
+is $ = (%maybe :some 2)
+  .bind (%maybe :some 1)
     fn (x)
-      :: maybe-class $ inc x
-is $ = (:: maybe-class nil)
-  .bind (:: maybe-class nil)
+      %maybe :some $ inc x
+
+is $ = (%maybe :none)
+  .bind (%maybe :none)
     fn (x)
-      :: maybe-class $ inc x
+      %maybe :some $ inc x
 
-is $ = (:: maybe-class 2)
-  .apply (:: maybe-class 1)
-    :: maybe-class inc
-is $ = (:: maybe-class nil)
-  .apply (:: maybe-class nil)
-    :: maybe-class inc
-is $ = (:: maybe-class nil)
-  .apply (:: maybe-class 1)
-    :: maybe-class nil
+; "\"apply"
 
-is $ = (:: maybe-class 1)
-  .alt (:: maybe-class 1)
-    :: maybe-class 2
-is $ = (:: maybe-class 1)
-  .alt (:: maybe-class 1)
-    :: maybe-class nil
-is $ = (:: maybe-class 2)
-  .alt (:: maybe-class nil)
-    :: maybe-class 2
-is $ = (:: maybe-class nil)
-  .alt (:: maybe-class nil)
-    :: maybe-class nil
+is $ = (%maybe :some 2)
+  .apply (%maybe :some 1)
+    %maybe :some inc
+
+is $ = (%maybe :none)
+  .apply (%maybe :none)
+    %maybe :some inc
+
+is $ = (%maybe :none)
+  .apply (%maybe :some 1)
+    %maybe :none
+
+; "\"alt"
+
+is $ = (%maybe :some 1)
+  .alt (%maybe :some 1)
+    %maybe :some 2
+
+is $ = (%maybe :some 1)
+  .alt (%maybe :some 1)
+    %maybe :none
+
+is $ = (%maybe :some 2)
+  .alt (%maybe :none)
+    %maybe :some 2
+
+is $ = (%maybe :none)
+  .alt (%maybe :none)
+    %maybe :none
 ```
 
 `checked-match` macro(much slower than `key-match`, not suggested to use):
 
 ```cirru
-ns demo
-  :require
-    algebra.match :refer $ checked-match
-
 defrecord! animal-class $ :variants
   {}
     :cat $ [] :name :color :age :breaks
@@ -65,21 +72,35 @@ defrecord! animal-class $ :variants
     :bird $ [] :name :category :origin
     :horse $ [] :name
 
-&let
-  pet $ :: animal-class ([] :cat "\"Mew" "\"orange" 6 20)
-  checked-match pet
-    (:cat name color age break-times)
-      println "\"Cat" name
-    (:dog name color age)
-      println "\"Dog" name
-    (:bird name _ origin)
-      println "\"Bird from" origin
-    (:horse name)
-      println "\"Horse"
-  checked-match pet
-    (:cat name color age break-times)
-      println "\"2.. Cat" name
-    _ $ println "\"not cat"
+; "\"example 1"
+is
+  =
+    match-pet-1 $ %:: animal-class :cat "\"Mew" "\"orange" 6 20
+    {} (:name "\"Mew")
+      :age 6
+      :color "\"orange"
+      :bad 20
+
+; "\"example 1"
+
+is
+  =
+    match-pet-1 $ %:: animal-class :horse "\"Jaky"
+    {} $ :name "\"Jaky"
+
+; "\"example 2"
+
+is
+  =
+    match-pet-2 $ %:: animal-class :cat "\"Mew" "\"orange" 6 20
+    [] "\"Cat" "\"Mew"
+
+; "\"example 2"
+
+is
+  =
+    match-pet-2 $ %:: animal-class :dog "\"Dou" "\"orange" 6
+    , "\"not cat"
 ```
 
 _TODO_

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ is $ = (%maybe :none)
     %maybe :none
 ```
 
-`checked-match` macro(much slower than `key-match`, not suggested to use):
+A demo of `tag-match` macro:
 
 ```cirru
 defrecord! animal-class $ :variants
@@ -71,6 +71,18 @@ defrecord! animal-class $ :variants
     :dog $ [] :name :color :age
     :bird $ [] :name :category :origin
     :horse $ [] :name
+
+defn match-pet-1 (pet)
+  tag-match pet
+      :cat name color age break-times
+      {} (:name name) (:color color) (:age age) (:bad break-times)
+    (:dog name color age)
+      {} (:name name) (:color color) (:age age)
+    (:bird name category origin)
+      {} (:name name) (:category category) (:origin origin)
+    (:horse name)
+      {} $ :name name
+    _ "\"unknown match result"
 
 ; "\"example 1"
 is

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -5,722 +5,6 @@
   :entries $ {}
   :ir $ {} (:package |algebra)
     :files $ {}
-      |algebra.match $ {}
-        :configs $ {}
-        :defs $ {}
-          |build-branching $ {} (:at 1633438559314) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633438559314) (:by |u0) (:text |defn) (:type :leaf)
-              |j $ {} (:at 1633438559314) (:by |u0) (:text |build-branching) (:type :leaf)
-              |r $ {} (:at 1633438559314) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633439016472) (:by |u0) (:text |var0) (:type :leaf)
-                  |T $ {} (:at 1633439011962) (:by |u0) (:text |patterns) (:type :leaf)
-              |v $ {} (:at 1633438676956) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633438677558) (:by |u0) (:text |if) (:type :leaf)
-                  |L $ {} (:at 1633438710480) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633438713183) (:by |u0) (:text |empty?) (:type :leaf)
-                      |j $ {} (:at 1633438715101) (:by |u0) (:text |patterns) (:type :leaf)
-                  |P $ {} (:at 1633438716275) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633440211761) (:by |u0) (:text |quasiquote) (:type :leaf)
-                      |j $ {} (:at 1633438720920) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633438721560) (:by |u0) (:text |raise) (:type :leaf)
-                          |j $ {} (:at 1633440179769) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633440180507) (:by |u0) (:text |str) (:type :leaf)
-                              |T $ {} (:at 1633440185234) (:by |u0) (:text "|\"unreachable in match for ") (:type :leaf)
-                              |j $ {} (:at 1633440201568) (:by |u0) (:text |~var0) (:type :leaf)
-                  |T $ {} (:at 1633438738795) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |D $ {} (:at 1633438757013) (:by |u0) (:text |&let) (:type :leaf)
-                      |L $ {} (:at 1633438740711) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633438741804) (:by |u0) (:text |p0) (:type :leaf)
-                          |j $ {} (:at 1633438742384) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633438743021) (:by |u0) (:text |first) (:type :leaf)
-                              |j $ {} (:at 1633438745221) (:by |u0) (:text |patterns) (:type :leaf)
-                      |P $ {} (:at 1633438758959) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633438763058) (:by |u0) (:text |&let) (:type :leaf)
-                          |j $ {} (:at 1633438763445) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633438764530) (:by |u0) (:text |rule) (:type :leaf)
-                              |j $ {} (:at 1633438764895) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633438768051) (:by |u0) (:text |nth) (:type :leaf)
-                                  |j $ {} (:at 1633438769308) (:by |u0) (:text |p0) (:type :leaf)
-                                  |r $ {} (:at 1633438769871) (:by |u0) (:text |0) (:type :leaf)
-                          |r $ {} (:at 1633438771833) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633438772313) (:by |u0) (:text |if) (:type :leaf)
-                              |j $ {} (:at 1633438772852) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633438773846) (:by |u0) (:text |=) (:type :leaf)
-                                  |j $ {} (:at 1633438775440) (:by |u0) (:text |'_) (:type :leaf)
-                                  |r $ {} (:at 1633438776232) (:by |u0) (:text |rule) (:type :leaf)
-                              |r $ {} (:at 1633438777871) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633438778498) (:by |u0) (:text |if) (:type :leaf)
-                                  |j $ {} (:at 1633438778853) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1633438784642) (:by |u0) (:text |=) (:type :leaf)
-                                      |L $ {} (:at 1633438788377) (:by |u0) (:text |1) (:type :leaf)
-                                      |T $ {} (:at 1633438788840) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |D $ {} (:at 1633438791836) (:by |u0) (:text |count) (:type :leaf)
-                                          |T $ {} (:at 1633438781295) (:by |u0) (:text |patterns) (:type :leaf)
-                                  |r $ {} (:at 1633438870490) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1633438871396) (:by |u0) (:text |nth) (:type :leaf)
-                                      |T $ {} (:at 1633438870302) (:by |u0) (:text |p0) (:type :leaf)
-                                      |j $ {} (:at 1633438872190) (:by |u0) (:text |1) (:type :leaf)
-                                  |v $ {} (:at 1633438807119) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1633438807883) (:by |u0) (:text |quote) (:type :leaf)
-                                      |T $ {} (:at 1633438802153) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633438804044) (:by |u0) (:text |raise) (:type :leaf)
-                                          |j $ {} (:at 1633438821306) (:by |u0) (:text "|\"expected `_` at last rule") (:type :leaf)
-                              |x $ {} (:at 1633439219045) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |D $ {} (:at 1633439223885) (:by |u0) (:text |quasiquote) (:type :leaf)
-                                  |T $ {} (:at 1633438954828) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633439218156) (:by |u0) (:text |if) (:type :leaf)
-                                      |j $ {} (:at 1633438966810) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633439212377) (:by |u0) (:text |=) (:type :leaf)
-                                          |j $ {} (:at 1633438971460) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633438973759) (:by |u0) (:text |nth) (:type :leaf)
-                                              |j $ {} (:at 1633439018287) (:by |u0) (:text |~var0) (:type :leaf)
-                                              |r $ {} (:at 1633438979390) (:by |u0) (:text |0) (:type :leaf)
-                                          |r $ {} (:at 1633439823463) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |D $ {} (:at 1633439826529) (:by |u0) (:text |~) (:type :leaf)
-                                              |T $ {} (:at 1633439023209) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633439031387) (:by |u0) (:text |nth) (:type :leaf)
-                                                  |j $ {} (:at 1633439821957) (:by |u0) (:text |rule) (:type :leaf)
-                                                  |r $ {} (:at 1633439036487) (:by |u0) (:text |0) (:type :leaf)
-                                      |r $ {} (:at 1633439063472) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |D $ {} (:at 1633439064105) (:by |u0) (:text |~) (:type :leaf)
-                                          |T $ {} (:at 1633439062930) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633439132367) (:by |u0) (:text |build-indexed-expr) (:type :leaf)
-                                              |Z $ {} (:at 1633439155448) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633439156934) (:by |u0) (:text |rest) (:type :leaf)
-                                                  |j $ {} (:at 1633439157879) (:by |u0) (:text |rule) (:type :leaf)
-                                              |f $ {} (:at 1633439136668) (:by |u0) (:text |var0) (:type :leaf)
-                                              |n $ {} (:at 1633439352740) (:by |u0) (:text |1) (:type :leaf)
-                                              |v $ {} (:at 1633439163060) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633439164545) (:by |u0) (:text |nth) (:type :leaf)
-                                                  |j $ {} (:at 1633439168446) (:by |u0) (:text |p0) (:type :leaf)
-                                                  |r $ {} (:at 1633439166932) (:by |u0) (:text |1) (:type :leaf)
-                                      |v $ {} (:at 1633439175385) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633439176201) (:by |u0) (:text |~) (:type :leaf)
-                                          |j $ {} (:at 1633439177013) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633439182344) (:by |u0) (:text |build-branching) (:type :leaf)
-                                              |j $ {} (:at 1633439183473) (:by |u0) (:text |var0) (:type :leaf)
-                                              |r $ {} (:at 1633439184389) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633439185152) (:by |u0) (:text |rest) (:type :leaf)
-                                                  |j $ {} (:at 1633439186522) (:by |u0) (:text |patterns) (:type :leaf)
-          |build-indexed-expr $ {} (:at 1633439230088) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633439230088) (:by |u0) (:text |defn) (:type :leaf)
-              |j $ {} (:at 1633439230088) (:by |u0) (:text |build-indexed-expr) (:type :leaf)
-              |r $ {} (:at 1633439230088) (:by |u0) (:type :expr)
-                :data $ {}
-                  |L $ {} (:at 1633439232632) (:by |u0) (:text |vars) (:type :leaf)
-                  |j $ {} (:at 1633439230088) (:by |u0) (:text |var0) (:type :leaf)
-                  |n $ {} (:at 1633439267435) (:by |u0) (:text |idx) (:type :leaf)
-                  |r $ {} (:at 1633439235238) (:by |u0) (:text |code) (:type :leaf)
-              |v $ {} (:at 1633439288404) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633439289407) (:by |u0) (:text |if) (:type :leaf)
-                  |j $ {} (:at 1633439289744) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633439291409) (:by |u0) (:text |empty?) (:type :leaf)
-                      |j $ {} (:at 1633439293458) (:by |u0) (:text |vars) (:type :leaf)
-                  |r $ {} (:at 1633439294324) (:by |u0) (:text |code) (:type :leaf)
-                  |v $ {} (:at 1633441268011) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |D $ {} (:at 1633441268734) (:by |u0) (:text |if) (:type :leaf)
-                      |L $ {} (:at 1633441269058) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633441270202) (:by |u0) (:text |=) (:type :leaf)
-                          |j $ {} (:at 1633441354753) (:by |u0) (:text |'_) (:type :leaf)
-                          |r $ {} (:at 1633441283907) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633441283907) (:by |u0) (:text |first) (:type :leaf)
-                              |j $ {} (:at 1633441283907) (:by |u0) (:text |vars) (:type :leaf)
-                      |P $ {} (:at 1633441290126) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633441290126) (:by |u0) (:text |build-indexed-expr) (:type :leaf)
-                          |j $ {} (:at 1633441290126) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633441290126) (:by |u0) (:text |rest) (:type :leaf)
-                              |j $ {} (:at 1633441290126) (:by |u0) (:text |vars) (:type :leaf)
-                          |r $ {} (:at 1633441290126) (:by |u0) (:text |var0) (:type :leaf)
-                          |v $ {} (:at 1633441290126) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633441290126) (:by |u0) (:text |inc) (:type :leaf)
-                              |j $ {} (:at 1633441290126) (:by |u0) (:text |idx) (:type :leaf)
-                          |x $ {} (:at 1633441290126) (:by |u0) (:text |code) (:type :leaf)
-                      |T $ {} (:at 1633439294636) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633439299607) (:by |u0) (:text |quasiquote) (:type :leaf)
-                          |j $ {} (:at 1633439300154) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633439309819) (:by |u0) (:text |&let) (:type :leaf)
-                              |j $ {} (:at 1633439321645) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633439314903) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1633439315855) (:by |u0) (:text |~) (:type :leaf)
-                                      |T $ {} (:at 1633439310260) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633439311621) (:by |u0) (:text |first) (:type :leaf)
-                                          |j $ {} (:at 1633439314236) (:by |u0) (:text |vars) (:type :leaf)
-                                  |j $ {} (:at 1633439366343) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633439343672) (:by |u0) (:text |nth) (:type :leaf)
-                                      |j $ {} (:at 1633439371969) (:by |u0) (:text |~var0) (:type :leaf)
-                                      |r $ {} (:at 1633439742091) (:by |u0) (:text |~idx) (:type :leaf)
-                              |r $ {} (:at 1633439375793) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633439376218) (:by |u0) (:text |~) (:type :leaf)
-                                  |j $ {} (:at 1633439379805) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633439382149) (:by |u0) (:text |build-indexed-expr) (:type :leaf)
-                                      |j $ {} (:at 1633439383269) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633439384249) (:by |u0) (:text |rest) (:type :leaf)
-                                          |j $ {} (:at 1633439385609) (:by |u0) (:text |vars) (:type :leaf)
-                                      |r $ {} (:at 1633439390388) (:by |u0) (:text |var0) (:type :leaf)
-                                      |v $ {} (:at 1633439391770) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633439392137) (:by |u0) (:text |inc) (:type :leaf)
-                                          |j $ {} (:at 1633439394244) (:by |u0) (:text |idx) (:type :leaf)
-                                      |x $ {} (:at 1633439395151) (:by |u0) (:text |code) (:type :leaf)
-          |check-definitions $ {} (:at 1633421215436) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633421221896) (:by |u0) (:text |defn) (:type :leaf)
-              |j $ {} (:at 1633421215436) (:by |u0) (:text |check-definitions) (:type :leaf)
-              |r $ {} (:at 1633421215436) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633421224118) (:by |u0) (:text |rules) (:type :leaf)
-                  |j $ {} (:at 1633421227319) (:by |u0) (:text |variants) (:type :leaf)
-              |t $ {} (:at 1633421229804) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633422286188) (:by |u0) (:text |;) (:type :leaf)
-                  |T $ {} (:at 1633421230618) (:by |u0) (:text |println) (:type :leaf)
-                  |j $ {} (:at 1633421232225) (:by |u0) (:text "|\"rules") (:type :leaf)
-                  |r $ {} (:at 1633421233881) (:by |u0) (:text |rules) (:type :leaf)
-              |u $ {} (:at 1633421355446) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633422284624) (:by |u0) (:text |;) (:type :leaf)
-                  |T $ {} (:at 1633421357447) (:by |u0) (:text |println) (:type :leaf)
-                  |j $ {} (:at 1633421358433) (:by |u0) (:text "|\"variants") (:type :leaf)
-                  |r $ {} (:at 1633421358983) (:by |u0) (:text |variants) (:type :leaf)
-              |uT $ {} (:at 1633421405630) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633421406058) (:by |u0) (:text |if) (:type :leaf)
-                  |j $ {} (:at 1633421406539) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633421408388) (:by |u0) (:text |empty?) (:type :leaf)
-                      |j $ {} (:at 1633421409596) (:by |u0) (:text |rules) (:type :leaf)
-                  |r $ {} (:at 1633422541564) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |D $ {} (:at 1633422543363) (:by |u0) (:text |if) (:type :leaf)
-                      |L $ {} (:at 1633422544683) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633422546557) (:by |u0) (:text |empty?) (:type :leaf)
-                          |j $ {} (:at 1633422548771) (:by |u0) (:text |variants) (:type :leaf)
-                      |T $ {} (:at 1633421410798) (:by |u0) (:text |true) (:type :leaf)
-                      |j $ {} (:at 1633422550768) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633422553444) (:by |u0) (:text |raise) (:type :leaf)
-                          |j $ {} (:at 1633422554662) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633422555147) (:by |u0) (:text |str) (:type :leaf)
-                              |j $ {} (:at 1633422565126) (:by |u0) (:text "|\"variants not covered:") (:type :leaf)
-                              |r $ {} (:at 1633422567212) (:by |u0) (:text |variants) (:type :leaf)
-                  |v $ {} (:at 1633421411310) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633421414314) (:by |u0) (:text |&let) (:type :leaf)
-                      |j $ {} (:at 1633421415137) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633421415794) (:by |u0) (:text |r0) (:type :leaf)
-                          |j $ {} (:at 1633421416360) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633421417647) (:by |u0) (:text |first) (:type :leaf)
-                              |j $ {} (:at 1633421418962) (:by |u0) (:text |rules) (:type :leaf)
-                      |r $ {} (:at 1633421841425) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |D $ {} (:at 1633421841937) (:by |u0) (:text |if) (:type :leaf)
-                          |L $ {} (:at 1633421842747) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633421844561) (:by |u0) (:text |list?) (:type :leaf)
-                              |j $ {} (:at 1633421846984) (:by |u0) (:text |r0) (:type :leaf)
-                          |T $ {} (:at 1633421539427) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633421540753) (:by |u0) (:text |&let) (:type :leaf)
-                              |L $ {} (:at 1633421541131) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633421541600) (:by |u0) (:text |key) (:type :leaf)
-                                  |j $ {} (:at 1633421541977) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633421544172) (:by |u0) (:text |first) (:type :leaf)
-                                      |j $ {} (:at 1633421545210) (:by |u0) (:text |r0) (:type :leaf)
-                              |N $ {} (:at 1633422012363) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633422012363) (:by |u0) (:text |assert) (:type :leaf)
-                                  |j $ {} (:at 1633422012363) (:by |u0) (:text "|\"variant key in keyword") (:type :leaf)
-                                  |r $ {} (:at 1633422012363) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633422012363) (:by |u0) (:text |keyword?) (:type :leaf)
-                                      |j $ {} (:at 1633422012363) (:by |u0) (:text |key) (:type :leaf)
-                              |g $ {} (:at 1633422021569) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633422022056) (:by |u0) (:text |if) (:type :leaf)
-                                  |j $ {} (:at 1633422022481) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633422028906) (:by |u0) (:text |&map:contains?) (:type :leaf)
-                                      |b $ {} (:at 1633422045622) (:by |u0) (:text |variants) (:type :leaf)
-                                      |j $ {} (:at 1633422042006) (:by |u0) (:text |key) (:type :leaf)
-                                  |r $ {} (:at 1633422047716) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633422062350) (:by |u0) (:text |if) (:type :leaf)
-                                      |j $ {} (:at 1633422064353) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633422063503) (:by |u0) (:text |=) (:type :leaf)
-                                          |j $ {} (:at 1633422074820) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633422075587) (:by |u0) (:text |count) (:type :leaf)
-                                              |j $ {} (:at 1633422077696) (:by |u0) (:text |r0) (:type :leaf)
-                                          |r $ {} (:at 1633422080650) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633422234293) (:by |u0) (:text |inc) (:type :leaf)
-                                              |j $ {} (:at 1633422199214) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |D $ {} (:at 1633422200636) (:by |u0) (:text |count) (:type :leaf)
-                                                  |T $ {} (:at 1633422082268) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633422086350) (:by |u0) (:text |get) (:type :leaf)
-                                                      |j $ {} (:at 1633422088076) (:by |u0) (:text |variants) (:type :leaf)
-                                                      |r $ {} (:at 1633422090082) (:by |u0) (:text |key) (:type :leaf)
-                                      |r $ {} (:at 1633422133250) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633422133936) (:by |u0) (:text |recur) (:type :leaf)
-                                          |j $ {} (:at 1633422139598) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633422138331) (:by |u0) (:text |rest) (:type :leaf)
-                                              |j $ {} (:at 1633422140758) (:by |u0) (:text |rules) (:type :leaf)
-                                          |r $ {} (:at 1633422141773) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633422142917) (:by |u0) (:text |dissoc) (:type :leaf)
-                                              |j $ {} (:at 1633422144736) (:by |u0) (:text |variants) (:type :leaf)
-                                              |r $ {} (:at 1633422146330) (:by |u0) (:text |key) (:type :leaf)
-                                      |v $ {} (:at 1633422148099) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633422148732) (:by |u0) (:text |raise) (:type :leaf)
-                                          |j $ {} (:at 1633422151574) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633422152714) (:by |u0) (:text |str) (:type :leaf)
-                                              |j $ {} (:at 1633422213309) (:by |u0) (:text "|\"invalid size of rule: ") (:type :leaf)
-                                              |r $ {} (:at 1633422170617) (:by |u0) (:text |r0) (:type :leaf)
-                                              |t $ {} (:at 1633422224302) (:by |u0) (:text "|\" ") (:type :leaf)
-                                              |v $ {} (:at 1633422174156) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633422174156) (:by |u0) (:text |get) (:type :leaf)
-                                                  |j $ {} (:at 1633422174156) (:by |u0) (:text |variants) (:type :leaf)
-                                                  |r $ {} (:at 1633422174156) (:by |u0) (:text |key) (:type :leaf)
-                                  |v $ {} (:at 1633422096366) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633422098736) (:by |u0) (:text |raise) (:type :leaf)
-                                      |j $ {} (:at 1633422103882) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |D $ {} (:at 1633422104929) (:by |u0) (:text |str) (:type :leaf)
-                                          |T $ {} (:at 1633422115675) (:by |u0) (:text "|\"unknown variant:") (:type :leaf)
-                                          |j $ {} (:at 1633422117480) (:by |u0) (:text |r0) (:type :leaf)
-                                          |r $ {} (:at 1633422125622) (:by |u0) (:text |variants) (:type :leaf)
-                          |j $ {} (:at 1633421851057) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633421851513) (:by |u0) (:text |if) (:type :leaf)
-                              |j $ {} (:at 1633421853654) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633421852559) (:by |u0) (:text |=) (:type :leaf)
-                                  |j $ {} (:at 1633421854839) (:by |u0) (:text |'_) (:type :leaf)
-                                  |r $ {} (:at 1633421856380) (:by |u0) (:text |r0) (:type :leaf)
-                              |r $ {} (:at 1633421908609) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |D $ {} (:at 1633421909139) (:by |u0) (:text |if) (:type :leaf)
-                                  |L $ {} (:at 1633421909401) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633421911551) (:by |u0) (:text |=) (:type :leaf)
-                                      |j $ {} (:at 1633421913588) (:by |u0) (:text |1) (:type :leaf)
-                                      |r $ {} (:at 1633421914226) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633421914890) (:by |u0) (:text |count) (:type :leaf)
-                                          |j $ {} (:at 1633421959607) (:by |u0) (:text |rules) (:type :leaf)
-                                  |T $ {} (:at 1633421865898) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633421866652) (:by |u0) (:text |if) (:type :leaf)
-                                      |j $ {} (:at 1633421867897) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633421870359) (:by |u0) (:text |empty?) (:type :leaf)
-                                          |j $ {} (:at 1633421872040) (:by |u0) (:text |variants) (:type :leaf)
-                                      |v $ {} (:at 1633421882312) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633421880237) (:by |u0) (:text |raise) (:type :leaf)
-                                          |j $ {} (:at 1633421889799) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633421891206) (:by |u0) (:text |str) (:type :leaf)
-                                              |j $ {} (:at 1633421984124) (:by |u0) (:text "|\"all variants covered, no need for `_` clause") (:type :leaf)
-                                      |x $ {} (:at 1633421902312) (:by |u0) (:text |true) (:type :leaf)
-                                  |j $ {} (:at 1633421919464) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633421928566) (:by |u0) (:text |raise) (:type :leaf)
-                                      |j $ {} (:at 1633421952246) (:by |u0) (:text "|\"expected `_` to be tail of patterns") (:type :leaf)
-          |checked-match $ {} (:at 1633411989390) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633411991684) (:by |u0) (:text |defmacro) (:type :leaf)
-              |j $ {} (:at 1633411989390) (:by |u0) (:text |checked-match) (:type :leaf)
-              |r $ {} (:at 1633411989390) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633421187809) (:by |u0) (:text |x0) (:type :leaf)
-                  |L $ {} (:at 1633420195236) (:by |u0) (:text |&) (:type :leaf)
-                  |T $ {} (:at 1633411995316) (:by |u0) (:text |patterns) (:type :leaf)
-              |v $ {} (:at 1633412074624) (:by |u0) (:type :expr)
-                :data $ {}
-                  |D $ {} (:at 1633412075879) (:by |u0) (:text |&let) (:type :leaf)
-                  |K $ {} (:at 1633413900817) (:by |u0) (:text |nil) (:type :leaf)
-                  |S $ {} (:at 1633413898735) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633413898735) (:by |u0) (:text |assert) (:type :leaf)
-                      |j $ {} (:at 1633413898735) (:by |u0) (:text "|\"pattern in format") (:type :leaf)
-                      |r $ {} (:at 1633413898735) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633413898735) (:by |u0) (:text |and) (:type :leaf)
-                          |j $ {} (:at 1633413898735) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633413898735) (:by |u0) (:text |list?) (:type :leaf)
-                              |j $ {} (:at 1633413917687) (:by |u0) (:text |patterns) (:type :leaf)
-                  |a $ {} (:at 1633415618041) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633415620352) (:by |u0) (:text |assert) (:type :leaf)
-                      |j $ {} (:at 1633415631608) (:by |u0) (:text "|\"check patterns") (:type :leaf)
-                      |r $ {} (:at 1633415632915) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633415638590) (:by |u0) (:text |every?) (:type :leaf)
-                          |j $ {} (:at 1633415641557) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633415643361) (:by |u0) (:text |butlast) (:type :leaf)
-                              |j $ {} (:at 1633415644837) (:by |u0) (:text |patterns) (:type :leaf)
-                          |r $ {} (:at 1633415653311) (:by |u0) (:text |valid-pattern?) (:type :leaf)
-                  |e $ {} (:at 1633415618041) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633415620352) (:by |u0) (:text |assert) (:type :leaf)
-                      |j $ {} (:at 1633415657708) (:by |u0) (:text "|\"check last pattern") (:type :leaf)
-                      |r $ {} (:at 1633415632915) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633415666075) (:by |u0) (:text |&let) (:type :leaf)
-                          |j $ {} (:at 1633415667349) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633415667860) (:by |u0) (:text |t) (:type :leaf)
-                              |T $ {} (:at 1633415641557) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633415659749) (:by |u0) (:text |last) (:type :leaf)
-                                  |j $ {} (:at 1633415644837) (:by |u0) (:text |patterns) (:type :leaf)
-                          |r $ {} (:at 1633415669681) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633415670676) (:by |u0) (:text |or) (:type :leaf)
-                              |L $ {} (:at 1633415683643) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633415692625) (:by |u0) (:text |valid-last-pattern?) (:type :leaf)
-                                  |j $ {} (:at 1633420548976) (:by |u0) (:text |t) (:type :leaf)
-                              |T $ {} (:at 1633415681408) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633415653311) (:by |u0) (:text |valid-pattern?) (:type :leaf)
-                                  |j $ {} (:at 1633415682609) (:by |u0) (:text |t) (:type :leaf)
-                  |g $ {} (:at 1633415695429) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633415697881) (:by |u0) (:text |&let) (:type :leaf)
-                      |j $ {} (:at 1633415698524) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633415780495) (:by |u0) (:text |defined-rules) (:type :leaf)
-                          |j $ {} (:at 1633415742340) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633415743155) (:by |u0) (:text |map) (:type :leaf)
-                              |T $ {} (:at 1633415739089) (:by |u0) (:text |patterns) (:type :leaf)
-                              |j $ {} (:at 1633415893289) (:by |u0) (:text |first) (:type :leaf)
-                      |n $ {} (:at 1633421101581) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |D $ {} (:at 1633421249601) (:by |u0) (:text |;) (:type :leaf)
-                          |T $ {} (:at 1633421102494) (:by |u0) (:text |println) (:type :leaf)
-                          |j $ {} (:at 1633421103707) (:by |u0) (:text "|\"defs") (:type :leaf)
-                          |r $ {} (:at 1633421105196) (:by |u0) (:text |defined-rules) (:type :leaf)
-                      |r $ {} (:at 1633440245593) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |D $ {} (:at 1633440247659) (:by |u0) (:text |&let) (:type :leaf)
-                          |L $ {} (:at 1633440251700) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633440288403) (:by |u0) (:text |boxed#) (:type :leaf)
-                              |j $ {} (:at 1633440292037) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633440294587) (:by |u0) (:text |gensym) (:type :leaf)
-                                  |j $ {} (:at 1633440297056) (:by |u0) (:text "|\"boxed") (:type :leaf)
-                          |T $ {} (:at 1633438389306) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |D $ {} (:at 1633438391897) (:by |u0) (:text |&let) (:type :leaf)
-                              |L $ {} (:at 1633438392943) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633440301055) (:by |u0) (:text |var#) (:type :leaf)
-                                  |j $ {} (:at 1633438397491) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1633438408389) (:by |u0) (:text |gensym) (:type :leaf)
-                                      |j $ {} (:at 1633440087384) (:by |u0) (:text "|\"value") (:type :leaf)
-                              |T $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633415755765) (:by |u0) (:text |quasiquote) (:type :leaf)
-                                  |j $ {} (:at 1633421163345) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |D $ {} (:at 1633421182246) (:by |u0) (:text |&let) (:type :leaf)
-                                      |L $ {} (:at 1633421164371) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633440315696) (:by |u0) (:text |~boxed#) (:type :leaf)
-                                          |j $ {} (:at 1633421203183) (:by |u0) (:text |~x0) (:type :leaf)
-                                      |P $ {} (:at 1633421192844) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633421192844) (:by |u0) (:text |assert) (:type :leaf)
-                                          |j $ {} (:at 1633421192844) (:by |u0) (:text "|\"expected tuple value") (:type :leaf)
-                                          |r $ {} (:at 1633421192844) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633421192844) (:by |u0) (:text |tuple?) (:type :leaf)
-                                              |j $ {} (:at 1633440322866) (:by |u0) (:text |~boxed#) (:type :leaf)
-                                      |T $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633415755765) (:by |u0) (:text |&let) (:type :leaf)
-                                          |j $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633415755765) (:by |u0) (:text |klass) (:type :leaf)
-                                              |j $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633415755765) (:by |u0) (:text |nth) (:type :leaf)
-                                                  |j $ {} (:at 1633440326707) (:by |u0) (:text |~boxed#) (:type :leaf)
-                                                  |r $ {} (:at 1633415755765) (:by |u0) (:text |0) (:type :leaf)
-                                          |r $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633415755765) (:by |u0) (:text |assert) (:type :leaf)
-                                              |j $ {} (:at 1633415755765) (:by |u0) (:text "|\"expected class in record") (:type :leaf)
-                                              |r $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633415755765) (:by |u0) (:text |record?) (:type :leaf)
-                                                  |j $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633415755765) (:by |u0) (:text |nth) (:type :leaf)
-                                                      |j $ {} (:at 1633440328402) (:by |u0) (:text |~boxed#) (:type :leaf)
-                                                      |r $ {} (:at 1633415755765) (:by |u0) (:text |0) (:type :leaf)
-                                          |v $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633415755765) (:by |u0) (:text |assert) (:type :leaf)
-                                              |j $ {} (:at 1633415755765) (:by |u0) (:text "|\"has variants") (:type :leaf)
-                                              |r $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633415755765) (:by |u0) (:text |map?) (:type :leaf)
-                                                  |j $ {} (:at 1633415755765) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633415755765) (:by |u0) (:text |:variants) (:type :leaf)
-                                                      |j $ {} (:at 1633415755765) (:by |u0) (:text |klass) (:type :leaf)
-                                          |w $ {} (:at 1633415825134) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |T $ {} (:at 1633415827073) (:by |u0) (:text |assert) (:type :leaf)
-                                              |j $ {} (:at 1633415836965) (:by |u0) (:text "|\"check all rules defined") (:type :leaf)
-                                              |r $ {} (:at 1633415839676) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |D $ {} (:at 1633422281110) (:by |u0) (:text |check-definitions) (:type :leaf)
-                                                  |L $ {} (:at 1633421090932) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |D $ {} (:at 1633421092295) (:by |u0) (:text |quote) (:type :leaf)
-                                                      |T $ {} (:at 1633415869502) (:by |u0) (:text |~defined-rules) (:type :leaf)
-                                                  |T $ {} (:at 1633415846773) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633415846773) (:by |u0) (:text |:variants) (:type :leaf)
-                                                      |j $ {} (:at 1633415846773) (:by |u0) (:text |klass) (:type :leaf)
-                                          |x $ {} (:at 1633440333454) (:by |u0) (:type :expr)
-                                            :data $ {}
-                                              |D $ {} (:at 1633440334596) (:by |u0) (:text |&let) (:type :leaf)
-                                              |L $ {} (:at 1633440341046) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633440347520) (:by |u0) (:text |~var#) (:type :leaf)
-                                                  |j $ {} (:at 1633440348209) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633440348776) (:by |u0) (:text |nth) (:type :leaf)
-                                                      |j $ {} (:at 1633440351876) (:by |u0) (:text |~boxed#) (:type :leaf)
-                                                      |r $ {} (:at 1633440353432) (:by |u0) (:text |1) (:type :leaf)
-                                              |N $ {} (:at 1633444831439) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633444832644) (:by |u0) (:text |assert) (:type :leaf)
-                                                  |j $ {} (:at 1633444840414) (:by |u0) (:text "|\"expected list for data") (:type :leaf)
-                                                  |r $ {} (:at 1633444845118) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |D $ {} (:at 1633444849296) (:by |u0) (:text |list?) (:type :leaf)
-                                                      |T $ {} (:at 1633444842831) (:by |u0) (:text |~var#) (:type :leaf)
-                                              |P $ {} (:at 1633444691185) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633444797313) (:by |u0) (:text |if) (:type :leaf)
-                                                  |j $ {} (:at 1633444798168) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633444798466) (:by |u0) (:text |not) (:type :leaf)
-                                                      |j $ {} (:at 1633444798860) (:by |u0) (:type :expr)
-                                                        :data $ {}
-                                                          |T $ {} (:at 1633444813919) (:by |u0) (:text |&map:contains?) (:type :leaf)
-                                                          |j $ {} (:at 1633444809030) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |T $ {} (:at 1633444809030) (:by |u0) (:text |:variants) (:type :leaf)
-                                                              |j $ {} (:at 1633444809030) (:by |u0) (:text |klass) (:type :leaf)
-                                                          |r $ {} (:at 1633444816633) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |T $ {} (:at 1633444818381) (:by |u0) (:text |nth) (:type :leaf)
-                                                              |j $ {} (:at 1633444828451) (:by |u0) (:text |~var#) (:type :leaf)
-                                                              |r $ {} (:at 1633444829469) (:by |u0) (:text |0) (:type :leaf)
-                                                  |r $ {} (:at 1633444851867) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |T $ {} (:at 1633444854885) (:by |u0) (:text |raise) (:type :leaf)
-                                                      |j $ {} (:at 1633444857611) (:by |u0) (:type :expr)
-                                                        :data $ {}
-                                                          |D $ {} (:at 1633444858430) (:by |u0) (:text |str) (:type :leaf)
-                                                          |T $ {} (:at 1633444864921) (:by |u0) (:text "|\"invalid key ") (:type :leaf)
-                                                          |j $ {} (:at 1633444868694) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |T $ {} (:at 1633444868694) (:by |u0) (:text |nth) (:type :leaf)
-                                                              |j $ {} (:at 1633444868694) (:by |u0) (:text |~var#) (:type :leaf)
-                                                              |r $ {} (:at 1633444868694) (:by |u0) (:text |0) (:type :leaf)
-                                                          |r $ {} (:at 1633444884344) (:by |u0) (:text "|\" according to ") (:type :leaf)
-                                                          |v $ {} (:at 1633444878481) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |T $ {} (:at 1633444878481) (:by |u0) (:text |:variants) (:type :leaf)
-                                                              |j $ {} (:at 1633444878481) (:by |u0) (:text |klass) (:type :leaf)
-                                              |T $ {} (:at 1633438445201) (:by |u0) (:type :expr)
-                                                :data $ {}
-                                                  |T $ {} (:at 1633438445859) (:by |u0) (:text |~) (:type :leaf)
-                                                  |j $ {} (:at 1633439472872) (:by |u0) (:type :expr)
-                                                    :data $ {}
-                                                      |D $ {} (:at 1633439474735) (:by |u0) (:text |&let) (:type :leaf)
-                                                      |T $ {} (:at 1633439475909) (:by |u0) (:type :expr)
-                                                        :data $ {}
-                                                          |D $ {} (:at 1633439476612) (:by |u0) (:text |code) (:type :leaf)
-                                                          |T $ {} (:at 1633438449246) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |T $ {} (:at 1633438521874) (:by |u0) (:text |build-branching) (:type :leaf)
-                                                              |j $ {} (:at 1633440309864) (:by |u0) (:text |var#) (:type :leaf)
-                                                              |r $ {} (:at 1633438482463) (:by |u0) (:text |patterns) (:type :leaf)
-                                                      |b $ {} (:at 1633439479727) (:by |u0) (:type :expr)
-                                                        :data $ {}
-                                                          |D $ {} (:at 1633445000132) (:by |u0) (:text |;) (:type :leaf)
-                                                          |T $ {} (:at 1633439480450) (:by |u0) (:text |println) (:type :leaf)
-                                                          |j $ {} (:at 1633439487888) (:by |u0) (:type :expr)
-                                                            :data $ {}
-                                                              |D $ {} (:at 1633439518625) (:by |u0) (:text |format-to-lisp) (:type :leaf)
-                                                              |T $ {} (:at 1633439482446) (:by |u0) (:text |code) (:type :leaf)
-                                                      |j $ {} (:at 1633439478818) (:by |u0) (:text |code) (:type :leaf)
-          |valid-last-pattern? $ {} (:at 1633420549837) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633420549837) (:by |u0) (:text |defn) (:type :leaf)
-              |j $ {} (:at 1633420549837) (:by |u0) (:text |valid-last-pattern?) (:type :leaf)
-              |r $ {} (:at 1633420549837) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633420742562) (:by |u0) (:text |xs) (:type :leaf)
-              |v $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633420552027) (:by |u0) (:text |and) (:type :leaf)
-                  |j $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420552027) (:by |u0) (:text |list?) (:type :leaf)
-                      |j $ {} (:at 1633420552027) (:by |u0) (:text |xs) (:type :leaf)
-                  |r $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420552027) (:by |u0) (:text |=) (:type :leaf)
-                      |j $ {} (:at 1633420552027) (:by |u0) (:text |2) (:type :leaf)
-                      |r $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633420552027) (:by |u0) (:text |count) (:type :leaf)
-                          |j $ {} (:at 1633420552027) (:by |u0) (:text |xs) (:type :leaf)
-                  |v $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420569158) (:by |u0) (:text |=) (:type :leaf)
-                      |b $ {} (:at 1633420571797) (:by |u0) (:text |'_) (:type :leaf)
-                      |j $ {} (:at 1633420552027) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633420552027) (:by |u0) (:text |nth) (:type :leaf)
-                          |j $ {} (:at 1633420552027) (:by |u0) (:text |xs) (:type :leaf)
-                          |r $ {} (:at 1633420552027) (:by |u0) (:text |0) (:type :leaf)
-          |valid-pattern? $ {} (:at 1633420213723) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1633420215036) (:by |u0) (:text |defn) (:type :leaf)
-              |j $ {} (:at 1633420213723) (:by |u0) (:text |valid-pattern?) (:type :leaf)
-              |r $ {} (:at 1633420213723) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633420217800) (:by |u0) (:text |xs) (:type :leaf)
-              |v $ {} (:at 1633420475789) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1633420477947) (:by |u0) (:text |and) (:type :leaf)
-                  |j $ {} (:at 1633420478247) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420481895) (:by |u0) (:text |list?) (:type :leaf)
-                      |j $ {} (:at 1633420480329) (:by |u0) (:text |xs) (:type :leaf)
-                  |r $ {} (:at 1633420483849) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420485174) (:by |u0) (:text |=) (:type :leaf)
-                      |j $ {} (:at 1633420485438) (:by |u0) (:text |2) (:type :leaf)
-                      |r $ {} (:at 1633420486154) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633420486835) (:by |u0) (:text |count) (:type :leaf)
-                          |j $ {} (:at 1633420487298) (:by |u0) (:text |xs) (:type :leaf)
-                  |v $ {} (:at 1633420488198) (:by |u0) (:type :expr)
-                    :data $ {}
-                      |T $ {} (:at 1633420499352) (:by |u0) (:text |&let) (:type :leaf)
-                      |j $ {} (:at 1633420501286) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1633420512674) (:by |u0) (:text |rule) (:type :leaf)
-                          |j $ {} (:at 1633420514451) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633420518671) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1633420519236) (:by |u0) (:text |xs) (:type :leaf)
-                              |r $ {} (:at 1633420519485) (:by |u0) (:text |0) (:type :leaf)
-                      |r $ {} (:at 1633420525190) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |D $ {} (:at 1633420527189) (:by |u0) (:text |and) (:type :leaf)
-                          |T $ {} (:at 1633420520544) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633420521959) (:by |u0) (:text |list?) (:type :leaf)
-                              |j $ {} (:at 1633420522967) (:by |u0) (:text |rule) (:type :leaf)
-                          |j $ {} (:at 1633420527763) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1633420530360) (:by |u0) (:text |keyword?) (:type :leaf)
-                              |j $ {} (:at 1633420530628) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1633420533677) (:by |u0) (:text |nth) (:type :leaf)
-                                  |j $ {} (:at 1633420726961) (:by |u0) (:text |rule) (:type :leaf)
-                                  |r $ {} (:at 1633420535251) (:by |u0) (:text |0) (:type :leaf)
-        :ns $ {} (:at 1633411984494) (:by |u0) (:type :expr)
-          :data $ {}
-            |T $ {} (:at 1633411984494) (:by |u0) (:text |ns) (:type :leaf)
-            |j $ {} (:at 1633411984494) (:by |u0) (:text |algebra.match) (:type :leaf)
-        :proc $ {} (:at 1633411984494) (:by |u0) (:type :expr)
-          :data $ {}
       |algebra.maybe $ {}
         :configs $ {}
         :defs $ {}
@@ -1056,7 +340,7 @@
                   |T $ {} (:at 1633443221954) (:by |u0) (:text |pet) (:type :leaf)
               |v $ {} (:at 1633443223347) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1633443223347) (:by |u0) (:text |checked-match) (:type :leaf)
+                  |T $ {} (:at 1685482906827) (:by |u0) (:text |tag-match) (:type :leaf)
                   |j $ {} (:at 1633443223347) (:by |u0) (:text |pet) (:type :leaf)
                   |r $ {} (:at 1633443223347) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1145,6 +429,10 @@
                             :data $ {}
                               |T $ {} (:at 1633443268282) (:by |u0) (:text |:name) (:type :leaf)
                               |j $ {} (:at 1633443269228) (:by |u0) (:text |name) (:type :leaf)
+                  |z $ {} (:at 1685482923101) (:by |u0) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1685482923868) (:by |u0) (:text |_) (:type :leaf)
+                      |b $ {} (:at 1685482935756) (:by |u0) (:text "|\"unknown match result") (:type :leaf)
           |match-pet-2 $ {} (:at 1633443392239) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1633443393416) (:by |u0) (:text |defn) (:type :leaf)
@@ -1154,7 +442,7 @@
                   |T $ {} (:at 1633443395378) (:by |u0) (:text |pet) (:type :leaf)
               |r $ {} (:at 1633443392239) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1633443392239) (:by |u0) (:text |checked-match) (:type :leaf)
+                  |T $ {} (:at 1685483013871) (:by |u0) (:text |tag-match) (:type :leaf)
                   |b $ {} (:at 1633444252516) (:by |u0) (:text |pet) (:type :leaf)
                   |j $ {} (:at 1633443392239) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1235,16 +523,13 @@
                                   |T $ {} (:at 1633443216293) (:by |u0) (:text |match-pet-1) (:type :leaf)
                                   |j $ {} (:at 1633443331765) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1633443331765) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1685482973245) (:by |u0) (:text |%::) (:type :leaf)
                                       |j $ {} (:at 1633443331765) (:by |u0) (:text |animal-class) (:type :leaf)
-                                      |r $ {} (:at 1633443331765) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633443331765) (:by |u0) (:text |[]) (:type :leaf)
-                                          |j $ {} (:at 1633443331765) (:by |u0) (:text |:cat) (:type :leaf)
-                                          |r $ {} (:at 1633443331765) (:by |u0) (:text "|\"Mew") (:type :leaf)
-                                          |v $ {} (:at 1633443331765) (:by |u0) (:text "|\"orange") (:type :leaf)
-                                          |x $ {} (:at 1633443331765) (:by |u0) (:text |6) (:type :leaf)
-                                          |y $ {} (:at 1633443331765) (:by |u0) (:text |20) (:type :leaf)
+                                      |r $ {} (:at 1633443331765) (:by |u0) (:text |:cat) (:type :leaf)
+                                      |t $ {} (:at 1633443331765) (:by |u0) (:text "|\"Mew") (:type :leaf)
+                                      |u $ {} (:at 1633443331765) (:by |u0) (:text "|\"orange") (:type :leaf)
+                                      |v $ {} (:at 1633443331765) (:by |u0) (:text |6) (:type :leaf)
+                                      |w $ {} (:at 1633443331765) (:by |u0) (:text |20) (:type :leaf)
                               |j $ {} (:at 1633443346134) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1633443346484) (:by |u0) (:text |{}) (:type :leaf)
@@ -1279,13 +564,10 @@
                                   |T $ {} (:at 1633443216293) (:by |u0) (:text |match-pet-1) (:type :leaf)
                                   |j $ {} (:at 1633443331765) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1633443331765) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1685482978296) (:by |u0) (:text |%::) (:type :leaf)
                                       |j $ {} (:at 1633443331765) (:by |u0) (:text |animal-class) (:type :leaf)
-                                      |r $ {} (:at 1633443331765) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633443331765) (:by |u0) (:text |[]) (:type :leaf)
-                                          |j $ {} (:at 1633444907250) (:by |u0) (:text |:horse) (:type :leaf)
-                                          |r $ {} (:at 1633444915682) (:by |u0) (:text "|\"Jaky") (:type :leaf)
+                                      |r $ {} (:at 1633444907250) (:by |u0) (:text |:horse) (:type :leaf)
+                                      |t $ {} (:at 1633444915682) (:by |u0) (:text "|\"Jaky") (:type :leaf)
                               |j $ {} (:at 1633443346134) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1633443346484) (:by |u0) (:text |{}) (:type :leaf)
@@ -1308,16 +590,13 @@
                                   |T $ {} (:at 1633443392239) (:by |u0) (:text |match-pet-2) (:type :leaf)
                                   |j $ {} (:at 1633443418194) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1633443418194) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1685482983339) (:by |u0) (:text |%::) (:type :leaf)
                                       |j $ {} (:at 1633443418194) (:by |u0) (:text |animal-class) (:type :leaf)
-                                      |r $ {} (:at 1633443418194) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633443418194) (:by |u0) (:text |[]) (:type :leaf)
-                                          |j $ {} (:at 1633443418194) (:by |u0) (:text |:cat) (:type :leaf)
-                                          |r $ {} (:at 1633443418194) (:by |u0) (:text "|\"Mew") (:type :leaf)
-                                          |v $ {} (:at 1633443418194) (:by |u0) (:text "|\"orange") (:type :leaf)
-                                          |x $ {} (:at 1633443418194) (:by |u0) (:text |6) (:type :leaf)
-                                          |y $ {} (:at 1633443418194) (:by |u0) (:text |20) (:type :leaf)
+                                      |t $ {} (:at 1633443418194) (:by |u0) (:text |:cat) (:type :leaf)
+                                      |u $ {} (:at 1633443418194) (:by |u0) (:text "|\"Mew") (:type :leaf)
+                                      |v $ {} (:at 1633443418194) (:by |u0) (:text "|\"orange") (:type :leaf)
+                                      |w $ {} (:at 1633443418194) (:by |u0) (:text |6) (:type :leaf)
+                                      |x $ {} (:at 1633443418194) (:by |u0) (:text |20) (:type :leaf)
                               |j $ {} (:at 1633443421387) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1633444317222) (:by |u0) (:text |[]) (:type :leaf)
@@ -1338,15 +617,12 @@
                                   |T $ {} (:at 1633443392239) (:by |u0) (:text |match-pet-2) (:type :leaf)
                                   |j $ {} (:at 1633443418194) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1633443418194) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1685482989214) (:by |u0) (:text |%::) (:type :leaf)
                                       |j $ {} (:at 1633443418194) (:by |u0) (:text |animal-class) (:type :leaf)
-                                      |r $ {} (:at 1633443418194) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1633443418194) (:by |u0) (:text |[]) (:type :leaf)
-                                          |j $ {} (:at 1633444938671) (:by |u0) (:text |:dog) (:type :leaf)
-                                          |r $ {} (:at 1633444950116) (:by |u0) (:text "|\"Dou") (:type :leaf)
-                                          |v $ {} (:at 1633443418194) (:by |u0) (:text "|\"orange") (:type :leaf)
-                                          |x $ {} (:at 1633443418194) (:by |u0) (:text |6) (:type :leaf)
+                                      |r $ {} (:at 1633444938671) (:by |u0) (:text |:dog) (:type :leaf)
+                                      |t $ {} (:at 1633444950116) (:by |u0) (:text "|\"Dou") (:type :leaf)
+                                      |u $ {} (:at 1633443418194) (:by |u0) (:text "|\"orange") (:type :leaf)
+                                      |v $ {} (:at 1633443418194) (:by |u0) (:text |6) (:type :leaf)
                               |j $ {} (:at 1633444382893) (:by |u0) (:text "|\"not cat") (:type :leaf)
           |test-maybe $ {} (:at 1625339983101) (:by |u0) (:type :expr)
             :data $ {}
@@ -1364,16 +640,18 @@
                           |T $ {} (:at 1625340056311) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1632902829234) (:by |u0) (:text |::) (:type :leaf)
+                              |D $ {} (:at 1685482773492) (:by |u0) (:text |%::) (:type :leaf)
                               |L $ {} (:at 1632902830841) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |P $ {} (:at 1685482769591) (:by |u0) (:text |:maybe) (:type :leaf)
                               |T $ {} (:at 1632902742608) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902745462) (:by |u0) (:text |.map) (:type :leaf)
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902748036) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1685482776747) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902753089) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482780569) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902753791) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1625340054484) (:by |u0) (:type :expr)
@@ -1384,16 +662,18 @@
                           |T $ {} (:at 1625340056311) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1632902829234) (:by |u0) (:text |::) (:type :leaf)
+                              |D $ {} (:at 1685482786772) (:by |u0) (:text |%::) (:type :leaf)
                               |L $ {} (:at 1632902830841) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |P $ {} (:at 1685482798058) (:by |u0) (:text |:maybe) (:type :leaf)
                               |T $ {} (:at 1632902845062) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902745462) (:by |u0) (:text |.map) (:type :leaf)
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902748036) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902748036) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902753089) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482799187) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902846265) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
               |v $ {} (:at 1632902852451) (:by |u0) (:type :expr)
@@ -1408,16 +688,18 @@
                           |T $ {} (:at 1632902864260) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902864260) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482801067) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632902864260) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902867176) (:by |u0) (:text |.bind) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482802594) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902864260) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
@@ -1427,8 +709,9 @@
                                       |T $ {} (:at 1632902872226) (:by |u0) (:text |x) (:type :leaf)
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |%::) (:type :leaf)
                                       |b $ {} (:at 1632902878594) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                      |f $ {} (:at 1685482804153) (:by |u0) (:text |:maybe) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -1441,16 +724,18 @@
                           |T $ {} (:at 1632902864260) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902864260) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482808925) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632902889197) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902867176) (:by |u0) (:text |.bind) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482807600) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902886082) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
@@ -1460,8 +745,9 @@
                                       |T $ {} (:at 1632902872226) (:by |u0) (:text |x) (:type :leaf)
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |::) (:type :leaf)
+                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |%::) (:type :leaf)
                                       |b $ {} (:at 1632902878594) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                      |f $ {} (:at 1685482805794) (:by |u0) (:text |:maybe) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -1478,21 +764,24 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482810386) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632902908365) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482817734) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902908365) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |::) (:type :leaf)
+                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
                                   |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |P $ {} (:at 1685482818998) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1502,21 +791,24 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482811870) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482816363) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902929181) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |::) (:type :leaf)
+                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
                                   |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |P $ {} (:at 1685482820130) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |x $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1526,21 +818,24 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482813100) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482815085) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902941751) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |::) (:type :leaf)
+                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
                                   |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |P $ {} (:at 1685482821447) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |T $ {} (:at 1632902939932) (:by |u0) (:text |nil) (:type :leaf)
               |y $ {} (:at 1632902984763) (:by |u0) (:type :expr)
                 :data $ {}
@@ -1554,21 +849,24 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482832923) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482831681) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482822819) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902999744) (:by |u0) (:text |2) (:type :leaf)
                   |v $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1578,21 +876,24 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482834025) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482830585) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482824282) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632903140647) (:by |u0) (:text |nil) (:type :leaf)
                   |x $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1602,21 +903,24 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482835002) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632903153036) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482829252) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482825946) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632903149144) (:by |u0) (:text |2) (:type :leaf)
                   |y $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -1626,21 +930,24 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                              |n $ {} (:at 1685482835977) (:by |u0) (:text |:maybe) (:type :leaf)
                               |r $ {} (:at 1632903160597) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482828189) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |::) (:type :leaf)
+                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
                                   |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
+                                  |n $ {} (:at 1685482827048) (:by |u0) (:text |:maybe) (:type :leaf)
                                   |r $ {} (:at 1632903157801) (:by |u0) (:text |nil) (:type :leaf)
         :ns $ {} (:at 1625339956346) (:by |u0) (:type :expr)
           :data $ {}
@@ -1666,13 +973,6 @@
                     |r $ {} (:at 1632902766517) (:by |u0) (:type :expr)
                       :data $ {}
                         |T $ {} (:at 1632902767077) (:by |u0) (:text |maybe-class) (:type :leaf)
-                |v $ {} (:at 1632902758969) (:by |u0) (:type :expr)
-                  :data $ {}
-                    |T $ {} (:at 1633419640702) (:by |u0) (:text |algebra.match) (:type :leaf)
-                    |j $ {} (:at 1632902766108) (:by |u0) (:text |:refer) (:type :leaf)
-                    |r $ {} (:at 1632902766517) (:by |u0) (:type :expr)
-                      :data $ {}
-                        |T $ {} (:at 1633419644904) (:by |u0) (:text |checked-match) (:type :leaf)
         :proc $ {} (:at 1625339956346) (:by |u0) (:type :expr)
           :data $ {}
   :users $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -252,6 +252,21 @@
       |algebra.test $ {}
         :configs $ {}
         :defs $ {}
+          |%maybe $ {} (:at 1685483614167) (:by |u0) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1685483618623) (:by |u0) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1685483614167) (:by |u0) (:text |%maybe) (:type :leaf)
+              |h $ {} (:at 1685483614167) (:by |u0) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1685483620328) (:by |u0) (:text |&) (:type :leaf)
+                  |b $ {} (:at 1685483621970) (:by |u0) (:text |args) (:type :leaf)
+              |l $ {} (:at 1685483623231) (:by |u0) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1685483623231) (:by |u0) (:text |%::) (:type :leaf)
+                  |b $ {} (:at 1685483623231) (:by |u0) (:text |maybe-class) (:type :leaf)
+                  |h $ {} (:at 1685483623231) (:by |u0) (:text |:maybe) (:type :leaf)
+                  |l $ {} (:at 1685483628879) (:by |u0) (:text |&) (:type :leaf)
+                  |o $ {} (:at 1685483629662) (:by |u0) (:text |args) (:type :leaf)
           |animal-class $ {} (:at 1633419682000) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1633419684488) (:by |u0) (:text |defrecord!) (:type :leaf)
@@ -640,18 +655,14 @@
                           |T $ {} (:at 1625340056311) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1685482773492) (:by |u0) (:text |%::) (:type :leaf)
-                              |L $ {} (:at 1632902830841) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |P $ {} (:at 1685482769591) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |D $ {} (:at 1685483612984) (:by |u0) (:text |%maybe) (:type :leaf)
                               |T $ {} (:at 1632902742608) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902745462) (:by |u0) (:text |.map) (:type :leaf)
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1685482776747) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902753089) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482780569) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685483644106) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902753791) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1625340054484) (:by |u0) (:type :expr)
@@ -662,18 +673,14 @@
                           |T $ {} (:at 1625340056311) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
-                              |D $ {} (:at 1685482786772) (:by |u0) (:text |%::) (:type :leaf)
-                              |L $ {} (:at 1632902830841) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |P $ {} (:at 1685482798058) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |D $ {} (:at 1685483649895) (:by |u0) (:text |%maybe) (:type :leaf)
                               |T $ {} (:at 1632902845062) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902745462) (:by |u0) (:text |.map) (:type :leaf)
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902748036) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902753089) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482799187) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |P $ {} (:at 1685483654807) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902846265) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
               |v $ {} (:at 1632902852451) (:by |u0) (:type :expr)
@@ -688,18 +695,14 @@
                           |T $ {} (:at 1632902864260) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482801067) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685483656668) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632902864260) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902867176) (:by |u0) (:text |.bind) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482802594) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482802594) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902864260) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
@@ -709,9 +712,7 @@
                                       |T $ {} (:at 1632902872226) (:by |u0) (:text |x) (:type :leaf)
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |%::) (:type :leaf)
-                                      |b $ {} (:at 1632902878594) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                      |f $ {} (:at 1685482804153) (:by |u0) (:text |:maybe) (:type :leaf)
+                                      |f $ {} (:at 1685482804153) (:by |u0) (:text |%maybe) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -724,18 +725,14 @@
                           |T $ {} (:at 1632902864260) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482808925) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482808925) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632902889197) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902867176) (:by |u0) (:text |.bind) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902864260) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902864260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482807600) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482807600) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902886082) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
@@ -745,9 +742,7 @@
                                       |T $ {} (:at 1632902872226) (:by |u0) (:text |x) (:type :leaf)
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1632902873670) (:by |u0) (:text |%::) (:type :leaf)
-                                      |b $ {} (:at 1632902878594) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                      |f $ {} (:at 1685482805794) (:by |u0) (:text |:maybe) (:type :leaf)
+                                      |f $ {} (:at 1685482805794) (:by |u0) (:text |%maybe) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -764,24 +759,18 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482810386) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482810386) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632902908365) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482817734) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482817734) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902908365) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
-                                  |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |P $ {} (:at 1685482818998) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |P $ {} (:at 1685482818998) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -791,24 +780,18 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482811870) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482811870) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482816363) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482816363) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902929181) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
-                                  |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |P $ {} (:at 1685482820130) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |P $ {} (:at 1685482820130) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |x $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -818,24 +801,18 @@
                           |T $ {} (:at 1632902908365) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482813100) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482813100) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902908365) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902908365) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482815085) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482815085) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902941751) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632902916560) (:by |u0) (:text |%::) (:type :leaf)
-                                  |L $ {} (:at 1632902918260) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |P $ {} (:at 1685482821447) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |P $ {} (:at 1685482821447) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |T $ {} (:at 1632902939932) (:by |u0) (:text |nil) (:type :leaf)
               |y $ {} (:at 1632902984763) (:by |u0) (:type :expr)
                 :data $ {}
@@ -849,24 +826,18 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482832923) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482832923) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482831681) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482831681) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482822819) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482822819) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902999744) (:by |u0) (:text |2) (:type :leaf)
                   |v $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -876,24 +847,18 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482834025) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482834025) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482830585) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482830585) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482824282) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482824282) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632903140647) (:by |u0) (:text |nil) (:type :leaf)
                   |x $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -903,24 +868,18 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482835002) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482835002) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632903153036) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482829252) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482829252) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482825946) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482825946) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632903149144) (:by |u0) (:text |2) (:type :leaf)
                   |y $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -930,24 +889,18 @@
                           |T $ {} (:at 1632902991454) (:by |u0) (:text |=) (:type :leaf)
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                              |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                              |n $ {} (:at 1685482835977) (:by |u0) (:text |:maybe) (:type :leaf)
+                              |n $ {} (:at 1685482835977) (:by |u0) (:text |%maybe) (:type :leaf)
                               |r $ {} (:at 1632903160597) (:by |u0) (:text |nil) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902991454) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902991454) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482828189) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482828189) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632902996751) (:by |u0) (:text |%::) (:type :leaf)
-                                  |j $ {} (:at 1632902999186) (:by |u0) (:text |maybe-class) (:type :leaf)
-                                  |n $ {} (:at 1685482827048) (:by |u0) (:text |:maybe) (:type :leaf)
+                                  |n $ {} (:at 1685482827048) (:by |u0) (:text |%maybe) (:type :leaf)
                                   |r $ {} (:at 1632903157801) (:by |u0) (:text |nil) (:type :leaf)
         :ns $ {} (:at 1625339956346) (:by |u0) (:type :expr)
           :data $ {}

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -8,6 +8,20 @@
       |algebra.maybe $ {}
         :configs $ {}
         :defs $ {}
+          |%maybe $ {} (:at 1685483614167) (:by |u0) (:type :expr)
+            :data $ {}
+              |T $ {} (:at 1685483618623) (:by |u0) (:text |defn) (:type :leaf)
+              |b $ {} (:at 1685505949243) (:by |u0) (:text |%maybe) (:type :leaf)
+              |h $ {} (:at 1685483614167) (:by |u0) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1685483620328) (:by |u0) (:text |&) (:type :leaf)
+                  |b $ {} (:at 1685483621970) (:by |u0) (:text |args) (:type :leaf)
+              |l $ {} (:at 1685483623231) (:by |u0) (:type :expr)
+                :data $ {}
+                  |T $ {} (:at 1685483623231) (:by |u0) (:text |%::) (:type :leaf)
+                  |b $ {} (:at 1685483623231) (:by |u0) (:text |maybe-class) (:type :leaf)
+                  |l $ {} (:at 1685483628879) (:by |u0) (:text |&) (:type :leaf)
+                  |o $ {} (:at 1685483629662) (:by |u0) (:text |args) (:type :leaf)
           |&alt-maybe $ {} (:at 1632723604203) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1632723605415) (:by |u0) (:text |defn) (:type :leaf)
@@ -16,37 +30,61 @@
                 :data $ {}
                   |T $ {} (:at 1632723608111) (:by |u0) (:text |self) (:type :leaf)
                   |j $ {} (:at 1632723617814) (:by |u0) (:text |other) (:type :leaf)
-              |v $ {} (:at 1632723618497) (:by |u0) (:type :expr)
+              |t $ {} (:at 1685549479329) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1632903117348) (:by |u0) (:text |let) (:type :leaf)
-                  |j $ {} (:at 1632903126147) (:by |u0) (:type :expr)
+                  |T $ {} (:at 1685549482699) (:by |u0) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1685549488511) (:by |u0) (:text |self) (:type :leaf)
+                  |h $ {} (:at 1685549488915) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632903121630) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549489495) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632723622034) (:by |u0) (:text |klass) (:type :leaf)
-                          |j $ {} (:at 1632903122657) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632903123337) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632903124615) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632903124855) (:by |u0) (:text |0) (:type :leaf)
-                      |j $ {} (:at 1632903127372) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549490319) (:by |u0) (:text |:none) (:type :leaf)
+                      |b $ {} (:at 1685549660890) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632723642046) (:by |u0) (:text |data) (:type :leaf)
-                          |j $ {} (:at 1632903127982) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549660890) (:by |u0) (:text |tag-match) (:type :leaf)
+                          |b $ {} (:at 1685549660890) (:by |u0) (:text |other) (:type :leaf)
+                          |h $ {} (:at 1685549660890) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632903128999) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632903130037) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632903130452) (:by |u0) (:text |1) (:type :leaf)
-                  |r $ {} (:at 1632723644092) (:by |u0) (:text |self) (:type :leaf)
-                  |v $ {} (:at 1632723644801) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1685549660890) (:by |u0) (:text |:none) (:type :leaf)
+                              |b $ {} (:at 1685549660890) (:by |u0) (:text |other) (:type :leaf)
+                          |l $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1685549660890) (:by |u0) (:text |:some) (:type :leaf)
+                                  |b $ {} (:at 1685549660890) (:by |u0) (:text |_x) (:type :leaf)
+                              |b $ {} (:at 1685549660890) (:by |u0) (:text |other) (:type :leaf)
+                          |o $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549660890) (:by |u0) (:text |_) (:type :leaf)
+                              |b $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                                :data $ {}
+                                  |T $ {} (:at 1685549660890) (:by |u0) (:text |raise) (:type :leaf)
+                                  |b $ {} (:at 1685549660890) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1685549660890) (:by |u0) (:text |str-spaced) (:type :leaf)
+                                      |b $ {} (:at 1685549660890) (:by |u0) (:text "|\"unknown other:") (:type :leaf)
+                                      |h $ {} (:at 1685549660890) (:by |u0) (:text |other) (:type :leaf)
+                  |l $ {} (:at 1685549497994) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632723661691) (:by |u0) (:text |if) (:type :leaf)
-                      |j $ {} (:at 1632723662412) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549498712) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632723663213) (:by |u0) (:text |some?) (:type :leaf)
-                          |j $ {} (:at 1632723681597) (:by |u0) (:text |data) (:type :leaf)
-                      |r $ {} (:at 1632723665680) (:by |u0) (:text |self) (:type :leaf)
-                      |v $ {} (:at 1632723672515) (:by |u0) (:text |other) (:type :leaf)
+                          |T $ {} (:at 1685549499167) (:by |u0) (:text |:some) (:type :leaf)
+                          |b $ {} (:at 1685549502691) (:by |u0) (:text |_x) (:type :leaf)
+                      |b $ {} (:at 1685549505687) (:by |u0) (:text |self) (:type :leaf)
+                  |o $ {} (:at 1685549626653) (:by |u0) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1685549627963) (:by |u0) (:text |_) (:type :leaf)
+                      |b $ {} (:at 1685549628322) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1685549629592) (:by |u0) (:text |raise) (:type :leaf)
+                          |b $ {} (:at 1685549630272) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549632115) (:by |u0) (:text |str-spaced) (:type :leaf)
+                              |b $ {} (:at 1685549637533) (:by |u0) (:text "|\"unkown self:") (:type :leaf)
+                              |h $ {} (:at 1685549639353) (:by |u0) (:text |self) (:type :leaf)
           |&apply-maybe $ {} (:at 1632722891564) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1632722893644) (:by |u0) (:text |defn) (:type :leaf)
@@ -55,88 +93,68 @@
                 :data $ {}
                   |T $ {} (:at 1632722895126) (:by |u0) (:text |self) (:type :leaf)
                   |j $ {} (:at 1632722901093) (:by |u0) (:text |mf) (:type :leaf)
-              |v $ {} (:at 1632722907069) (:by |u0) (:type :expr)
+              |t $ {} (:at 1685549340263) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1632722907518) (:by |u0) (:text |let) (:type :leaf)
-                  |j $ {} (:at 1632722907764) (:by |u0) (:type :expr)
+                  |T $ {} (:at 1685549348154) (:by |u0) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1685549349572) (:by |u0) (:text |self) (:type :leaf)
+                  |h $ {} (:at 1685549349878) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632722907931) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549351144) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722912040) (:by |u0) (:text |klass) (:type :leaf)
-                          |j $ {} (:at 1632722912474) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722913264) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722913860) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722914648) (:by |u0) (:text |0) (:type :leaf)
-                      |j $ {} (:at 1632722915455) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1632722916075) (:by |u0) (:text |data) (:type :leaf)
-                          |j $ {} (:at 1632722916357) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722916850) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722917656) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722918017) (:by |u0) (:text |1) (:type :leaf)
-                  |r $ {} (:at 1632722919355) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549353176) (:by |u0) (:text |:none) (:type :leaf)
+                      |b $ {} (:at 1685549356694) (:by |u0) (:text |self) (:type :leaf)
+                  |l $ {} (:at 1685549357614) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632723040143) (:by |u0) (:text |if) (:type :leaf)
-                      |j $ {} (:at 1632723040332) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549358792) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632723041713) (:by |u0) (:text |nil?) (:type :leaf)
-                          |j $ {} (:at 1632723042940) (:by |u0) (:text |data) (:type :leaf)
-                      |r $ {} (:at 1632723381105) (:by |u0) (:text |self) (:type :leaf)
-                      |v $ {} (:at 1632723382679) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549360791) (:by |u0) (:text |:some) (:type :leaf)
+                          |b $ {} (:at 1685549361339) (:by |u0) (:text |x) (:type :leaf)
+                      |b $ {} (:at 1685549362135) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632723384902) (:by |u0) (:text |let) (:type :leaf)
-                          |j $ {} (:at 1632723385308) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549365027) (:by |u0) (:text |tag-match) (:type :leaf)
+                          |b $ {} (:at 1685549387311) (:by |u0) (:text |mf) (:type :leaf)
+                          |h $ {} (:at 1685549387886) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632723385492) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1685549391635) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632723388567) (:by |u0) (:text |c2) (:type :leaf)
-                                  |j $ {} (:at 1632723390186) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1632723390913) (:by |u0) (:text |nth) (:type :leaf)
-                                      |j $ {} (:at 1632723392727) (:by |u0) (:text |mf) (:type :leaf)
-                                      |r $ {} (:at 1632723402403) (:by |u0) (:text |0) (:type :leaf)
-                              |j $ {} (:at 1632723394830) (:by |u0) (:type :expr)
-                                :data $ {}
-                                  |T $ {} (:at 1632723514245) (:by |u0) (:text |f) (:type :leaf)
-                                  |j $ {} (:at 1632723395979) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1632723396547) (:by |u0) (:text |nth) (:type :leaf)
-                                      |j $ {} (:at 1632723397858) (:by |u0) (:text |mf) (:type :leaf)
-                                      |r $ {} (:at 1632723400158) (:by |u0) (:text |1) (:type :leaf)
-                          |r $ {} (:at 1632723403948) (:by |u0) (:type :expr)
+                                  |T $ {} (:at 1685549390877) (:by |u0) (:text |:none) (:type :leaf)
+                              |b $ {} (:at 1685549401204) (:by |u0) (:text |mf) (:type :leaf)
+                          |l $ {} (:at 1685549404994) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632723409035) (:by |u0) (:text |if) (:type :leaf)
-                              |j $ {} (:at 1632723413762) (:by |u0) (:type :expr)
+                              |T $ {} (:at 1685549405927) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |D $ {} (:at 1632723417585) (:by |u0) (:text |not=) (:type :leaf)
-                                  |T $ {} (:at 1632723410977) (:by |u0) (:text |c2) (:type :leaf)
-                                  |j $ {} (:at 1632723424344) (:by |u0) (:text |klass) (:type :leaf)
-                              |r $ {} (:at 1632723426070) (:by |u0) (:type :expr)
+                                  |T $ {} (:at 1685549406368) (:by |u0) (:text |:some) (:type :leaf)
+                                  |b $ {} (:at 1685549406795) (:by |u0) (:text |f) (:type :leaf)
+                              |b $ {} (:at 1685549408001) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632723428459) (:by |u0) (:text |raise) (:type :leaf)
-                                  |j $ {} (:at 1632723459847) (:by |u0) (:text "|\"expected maybe data") (:type :leaf)
-                              |v $ {} (:at 1632723460710) (:by |u0) (:type :expr)
+                                  |T $ {} (:at 1685549413162) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |b $ {} (:at 1685549414778) (:by |u0) (:text |:some) (:type :leaf)
+                                  |h $ {} (:at 1685549415225) (:by |u0) (:type :expr)
+                                    :data $ {}
+                                      |T $ {} (:at 1685549415381) (:by |u0) (:text |f) (:type :leaf)
+                                      |b $ {} (:at 1685549416427) (:by |u0) (:text |x) (:type :leaf)
+                          |o $ {} (:at 1685549418396) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549418760) (:by |u0) (:text |_) (:type :leaf)
+                              |b $ {} (:at 1685549419751) (:by |u0) (:type :expr)
                                 :data $ {}
-                                  |T $ {} (:at 1632723465538) (:by |u0) (:text |if) (:type :leaf)
-                                  |j $ {} (:at 1632723466394) (:by |u0) (:type :expr)
+                                  |T $ {} (:at 1685549421470) (:by |u0) (:text |raise) (:type :leaf)
+                                  |b $ {} (:at 1685549422802) (:by |u0) (:type :expr)
                                     :data $ {}
-                                      |T $ {} (:at 1632723471842) (:by |u0) (:text |nil?) (:type :leaf)
-                                      |j $ {} (:at 1632902970359) (:by |u0) (:text |f) (:type :leaf)
-                                  |r $ {} (:at 1632723490968) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1632723491689) (:by |u0) (:text |::) (:type :leaf)
-                                      |j $ {} (:at 1632723493672) (:by |u0) (:text |klass) (:type :leaf)
-                                      |r $ {} (:at 1632723494249) (:by |u0) (:text |nil) (:type :leaf)
-                                  |v $ {} (:at 1632723495446) (:by |u0) (:type :expr)
-                                    :data $ {}
-                                      |T $ {} (:at 1632723507035) (:by |u0) (:text |::) (:type :leaf)
-                                      |j $ {} (:at 1632723508348) (:by |u0) (:text |klass) (:type :leaf)
-                                      |r $ {} (:at 1632723516087) (:by |u0) (:type :expr)
-                                        :data $ {}
-                                          |T $ {} (:at 1632723516601) (:by |u0) (:text |f) (:type :leaf)
-                                          |j $ {} (:at 1632723517316) (:by |u0) (:text |data) (:type :leaf)
+                                      |T $ {} (:at 1685549424458) (:by |u0) (:text |str-spaced) (:type :leaf)
+                                      |b $ {} (:at 1685549427361) (:by |u0) (:text "|\"unknown mf") (:type :leaf)
+                                      |h $ {} (:at 1685549431496) (:by |u0) (:text |mf) (:type :leaf)
+                  |o $ {} (:at 1685549366044) (:by |u0) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1685549366345) (:by |u0) (:text |_) (:type :leaf)
+                      |b $ {} (:at 1685549367013) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1685549368473) (:by |u0) (:text |raise) (:type :leaf)
+                          |b $ {} (:at 1685549369112) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549377154) (:by |u0) (:text |str-spaced) (:type :leaf)
+                              |b $ {} (:at 1685549380298) (:by |u0) (:text "|\"unkown data") (:type :leaf)
+                              |h $ {} (:at 1685549384454) (:by |u0) (:text |self) (:type :leaf)
           |&bind-maybe $ {} (:at 1632722712074) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1632722714039) (:by |u0) (:text |defn) (:type :leaf)
@@ -145,39 +163,37 @@
                 :data $ {}
                   |T $ {} (:at 1632722715266) (:by |u0) (:text |self) (:type :leaf)
                   |j $ {} (:at 1632722717897) (:by |u0) (:text |fm) (:type :leaf)
-              |v $ {} (:at 1632722718457) (:by |u0) (:type :expr)
+              |t $ {} (:at 1685549189757) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1632722721856) (:by |u0) (:text |let) (:type :leaf)
-                  |j $ {} (:at 1632722722118) (:by |u0) (:type :expr)
+                  |T $ {} (:at 1685549193477) (:by |u0) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1685549195054) (:by |u0) (:text |self) (:type :leaf)
+                  |h $ {} (:at 1685549196603) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632722722277) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549200567) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722724219) (:by |u0) (:text |klass) (:type :leaf)
-                          |j $ {} (:at 1632722724506) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722726429) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722728362) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722728558) (:by |u0) (:text |0) (:type :leaf)
-                      |j $ {} (:at 1632722729472) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1632722730817) (:by |u0) (:text |data) (:type :leaf)
-                          |j $ {} (:at 1632722731672) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722731977) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722733256) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722733556) (:by |u0) (:text |1) (:type :leaf)
-                  |r $ {} (:at 1632722734450) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549203050) (:by |u0) (:text |:none) (:type :leaf)
+                      |b $ {} (:at 1685549206428) (:by |u0) (:text |self) (:type :leaf)
+                  |l $ {} (:at 1685549208292) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632722735478) (:by |u0) (:text |if) (:type :leaf)
-                      |j $ {} (:at 1632722736371) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685549209177) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722736649) (:by |u0) (:text |nil?) (:type :leaf)
-                          |j $ {} (:at 1632722737251) (:by |u0) (:text |data) (:type :leaf)
-                      |n $ {} (:at 1632722758213) (:by |u0) (:text |self) (:type :leaf)
-                      |r $ {} (:at 1632722742366) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685549210952) (:by |u0) (:text |:some) (:type :leaf)
+                          |b $ {} (:at 1685549211775) (:by |u0) (:text |x) (:type :leaf)
+                      |b $ {} (:at 1685549212454) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722743263) (:by |u0) (:text |fm) (:type :leaf)
-                          |j $ {} (:at 1632722747188) (:by |u0) (:text |data) (:type :leaf)
+                          |T $ {} (:at 1685549217198) (:by |u0) (:text |fm) (:type :leaf)
+                          |b $ {} (:at 1685549218031) (:by |u0) (:text |x) (:type :leaf)
+                  |o $ {} (:at 1685549230015) (:by |u0) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1685549230505) (:by |u0) (:text |_) (:type :leaf)
+                      |b $ {} (:at 1685549231920) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1685549232724) (:by |u0) (:text |raise) (:type :leaf)
+                          |b $ {} (:at 1685549234721) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |T $ {} (:at 1685549235819) (:by |u0) (:text |str) (:type :leaf)
+                              |b $ {} (:at 1685549238650) (:by |u0) (:text "|\"unknown ") (:type :leaf)
+                              |h $ {} (:at 1685549240175) (:by |u0) (:text |self) (:type :leaf)
           |&map-maybe $ {} (:at 1632722696071) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1632722700000) (:by |u0) (:text |defn) (:type :leaf)
@@ -186,43 +202,41 @@
                 :data $ {}
                   |T $ {} (:at 1632722697140) (:by |u0) (:text |self) (:type :leaf)
                   |j $ {} (:at 1632722697140) (:by |u0) (:text |f) (:type :leaf)
-              |v $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+              |t $ {} (:at 1685505892142) (:by |u0) (:type :expr)
                 :data $ {}
-                  |T $ {} (:at 1632722697140) (:by |u0) (:text |let) (:type :leaf)
-                  |j $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                  |T $ {} (:at 1685505897194) (:by |u0) (:text |tag-match) (:type :leaf)
+                  |b $ {} (:at 1685505900425) (:by |u0) (:text |self) (:type :leaf)
+                  |h $ {} (:at 1685505910272) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685505903247) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722697140) (:by |u0) (:text |klass) (:type :leaf)
-                          |j $ {} (:at 1632722697140) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722697140) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722697140) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722697140) (:by |u0) (:text |0) (:type :leaf)
-                      |j $ {} (:at 1632722697140) (:by |u0) (:type :expr)
-                        :data $ {}
-                          |T $ {} (:at 1632722697140) (:by |u0) (:text |data) (:type :leaf)
-                          |j $ {} (:at 1632722697140) (:by |u0) (:type :expr)
-                            :data $ {}
-                              |T $ {} (:at 1632722697140) (:by |u0) (:text |nth) (:type :leaf)
-                              |j $ {} (:at 1632722697140) (:by |u0) (:text |self) (:type :leaf)
-                              |r $ {} (:at 1632722697140) (:by |u0) (:text |1) (:type :leaf)
-                  |r $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                          |b $ {} (:at 1685505907339) (:by |u0) (:text |:none) (:type :leaf)
+                      |b $ {} (:at 1685505923596) (:by |u0) (:text |self) (:type :leaf)
+                  |l $ {} (:at 1685505924603) (:by |u0) (:type :expr)
                     :data $ {}
-                      |T $ {} (:at 1632722697140) (:by |u0) (:text |if) (:type :leaf)
-                      |j $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                      |T $ {} (:at 1685505927406) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722697140) (:by |u0) (:text |nil?) (:type :leaf)
-                          |j $ {} (:at 1632722697140) (:by |u0) (:text |data) (:type :leaf)
-                      |r $ {} (:at 1632722697140) (:by |u0) (:text |self) (:type :leaf)
-                      |v $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685505927815) (:by |u0) (:text |:some) (:type :leaf)
+                          |b $ {} (:at 1685505929065) (:by |u0) (:text |x) (:type :leaf)
+                      |b $ {} (:at 1685505929889) (:by |u0) (:type :expr)
                         :data $ {}
-                          |T $ {} (:at 1632722697140) (:by |u0) (:text |::) (:type :leaf)
-                          |j $ {} (:at 1632722697140) (:by |u0) (:text |klass) (:type :leaf)
-                          |r $ {} (:at 1632722697140) (:by |u0) (:type :expr)
+                          |T $ {} (:at 1685505937030) (:by |u0) (:text |%maybe) (:type :leaf)
+                          |b $ {} (:at 1685505972378) (:by |u0) (:text |:some) (:type :leaf)
+                          |h $ {} (:at 1685505972731) (:by |u0) (:type :expr)
                             :data $ {}
-                              |T $ {} (:at 1632722697140) (:by |u0) (:text |f) (:type :leaf)
-                              |j $ {} (:at 1632722697140) (:by |u0) (:text |data) (:type :leaf)
+                              |T $ {} (:at 1685505973608) (:by |u0) (:text |f) (:type :leaf)
+                              |b $ {} (:at 1685505975945) (:by |u0) (:text |x) (:type :leaf)
+                  |o $ {} (:at 1685505987612) (:by |u0) (:type :expr)
+                    :data $ {}
+                      |T $ {} (:at 1685505988377) (:by |u0) (:text |_) (:type :leaf)
+                      |b $ {} (:at 1685505989596) (:by |u0) (:type :expr)
+                        :data $ {}
+                          |T $ {} (:at 1685505991615) (:by |u0) (:text |raise) (:type :leaf)
+                          |b $ {} (:at 1685510359549) (:by |u0) (:type :expr)
+                            :data $ {}
+                              |D $ {} (:at 1685510360266) (:by |u0) (:text |str) (:type :leaf)
+                              |T $ {} (:at 1685505996056) (:by |u0) (:text "|\"invalid case") (:type :leaf)
+                              |b $ {} (:at 1685510361837) (:by |u0) (:text |self) (:type :leaf)
           |maybe-class $ {} (:at 1632722546261) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1632722554180) (:by |u0) (:text |defrecord!) (:type :leaf)
@@ -252,21 +266,6 @@
       |algebra.test $ {}
         :configs $ {}
         :defs $ {}
-          |%maybe $ {} (:at 1685483614167) (:by |u0) (:type :expr)
-            :data $ {}
-              |T $ {} (:at 1685483618623) (:by |u0) (:text |defn) (:type :leaf)
-              |b $ {} (:at 1685483614167) (:by |u0) (:text |%maybe) (:type :leaf)
-              |h $ {} (:at 1685483614167) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1685483620328) (:by |u0) (:text |&) (:type :leaf)
-                  |b $ {} (:at 1685483621970) (:by |u0) (:text |args) (:type :leaf)
-              |l $ {} (:at 1685483623231) (:by |u0) (:type :expr)
-                :data $ {}
-                  |T $ {} (:at 1685483623231) (:by |u0) (:text |%::) (:type :leaf)
-                  |b $ {} (:at 1685483623231) (:by |u0) (:text |maybe-class) (:type :leaf)
-                  |h $ {} (:at 1685483623231) (:by |u0) (:text |:maybe) (:type :leaf)
-                  |l $ {} (:at 1685483628879) (:by |u0) (:text |&) (:type :leaf)
-                  |o $ {} (:at 1685483629662) (:by |u0) (:text |args) (:type :leaf)
           |animal-class $ {} (:at 1633419682000) (:by |u0) (:type :expr)
             :data $ {}
               |T $ {} (:at 1633419684488) (:by |u0) (:text |defrecord!) (:type :leaf)
@@ -656,14 +655,14 @@
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
                               |D $ {} (:at 1685483612984) (:by |u0) (:text |%maybe) (:type :leaf)
-                              |T $ {} (:at 1632902742608) (:by |u0) (:text |nil) (:type :leaf)
+                              |T $ {} (:at 1685510396430) (:by |u0) (:text |:none) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902745462) (:by |u0) (:text |.map) (:type :leaf)
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685483644106) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632902753791) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1685510398857) (:by |u0) (:text |:none) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1625340054484) (:by |u0) (:type :expr)
                     :data $ {}
@@ -674,6 +673,7 @@
                           |j $ {} (:at 1632902828014) (:by |u0) (:type :expr)
                             :data $ {}
                               |D $ {} (:at 1685483649895) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |L $ {} (:at 1685510402035) (:by |u0) (:text |:some) (:type :leaf)
                               |T $ {} (:at 1632902845062) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902743929) (:by |u0) (:type :expr)
                             :data $ {}
@@ -681,6 +681,7 @@
                               |j $ {} (:at 1632902746553) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |P $ {} (:at 1685483654807) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |d $ {} (:at 1685510405012) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902846265) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902816407) (:by |u0) (:text |inc) (:type :leaf)
               |v $ {} (:at 1632902852451) (:by |u0) (:type :expr)
@@ -696,6 +697,7 @@
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685483656668) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |p $ {} (:at 1685510407058) (:by |u0) (:text |:some) (:type :leaf)
                               |r $ {} (:at 1632902864260) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
@@ -703,6 +705,7 @@
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482802594) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510409244) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902864260) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
@@ -713,6 +716,7 @@
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
                                       |f $ {} (:at 1685482804153) (:by |u0) (:text |%maybe) (:type :leaf)
+                                      |h $ {} (:at 1685510417460) (:by |u0) (:text |:some) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -726,14 +730,14 @@
                           |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482808925) (:by |u0) (:text |%maybe) (:type :leaf)
-                              |r $ {} (:at 1632902889197) (:by |u0) (:text |nil) (:type :leaf)
+                              |p $ {} (:at 1685510424191) (:by |u0) (:text |:none) (:type :leaf)
                           |r $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902867176) (:by |u0) (:text |.bind) (:type :leaf)
                               |j $ {} (:at 1632902864260) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482807600) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632902886082) (:by |u0) (:text |nil) (:type :leaf)
+                                  |p $ {} (:at 1685510421708) (:by |u0) (:text |:none) (:type :leaf)
                               |r $ {} (:at 1632902871047) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |T $ {} (:at 1632902871304) (:by |u0) (:text |fn) (:type :leaf)
@@ -743,6 +747,7 @@
                                   |r $ {} (:at 1632902872730) (:by |u0) (:type :expr)
                                     :data $ {}
                                       |f $ {} (:at 1685482805794) (:by |u0) (:text |%maybe) (:type :leaf)
+                                      |h $ {} (:at 1685510427200) (:by |u0) (:text |:some) (:type :leaf)
                                       |j $ {} (:at 1632902875530) (:by |u0) (:type :expr)
                                         :data $ {}
                                           |T $ {} (:at 1632902875977) (:by |u0) (:text |inc) (:type :leaf)
@@ -760,6 +765,7 @@
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482810386) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |p $ {} (:at 1685510429651) (:by |u0) (:text |:some) (:type :leaf)
                               |r $ {} (:at 1632902908365) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
@@ -767,10 +773,12 @@
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482817734) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510431299) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902908365) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |P $ {} (:at 1685482818998) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |R $ {} (:at 1685549685893) (:by |u0) (:text |:some) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |v $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -781,17 +789,18 @@
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482811870) (:by |u0) (:text |%maybe) (:type :leaf)
-                              |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
+                              |r $ {} (:at 1685510435292) (:by |u0) (:text |:none) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482816363) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632902929181) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1632902929181) (:by |u0) (:text |:none) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |P $ {} (:at 1685482820130) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |R $ {} (:at 1685549683853) (:by |u0) (:text |:some) (:type :leaf)
                                   |T $ {} (:at 1632902908365) (:by |u0) (:text |inc) (:type :leaf)
                   |x $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                     :data $ {}
@@ -802,18 +811,19 @@
                           |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482813100) (:by |u0) (:text |%maybe) (:type :leaf)
-                              |r $ {} (:at 1632902934733) (:by |u0) (:text |nil) (:type :leaf)
+                              |r $ {} (:at 1632902934733) (:by |u0) (:text |:none) (:type :leaf)
                           |r $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902913469) (:by |u0) (:text |.apply) (:type :leaf)
                               |j $ {} (:at 1632902908365) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482815085) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510447981) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902941751) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902915687) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |P $ {} (:at 1685482821447) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |T $ {} (:at 1632902939932) (:by |u0) (:text |nil) (:type :leaf)
+                                  |T $ {} (:at 1632902939932) (:by |u0) (:text |:none) (:type :leaf)
               |y $ {} (:at 1632902984763) (:by |u0) (:type :expr)
                 :data $ {}
                   |T $ {} (:at 1632902985748) (:by |u0) (:text |testing) (:type :leaf)
@@ -827,6 +837,7 @@
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482832923) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |p $ {} (:at 1685510452207) (:by |u0) (:text |:some) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
@@ -834,10 +845,12 @@
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482831681) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510451336) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482822819) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510450323) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902999744) (:by |u0) (:text |2) (:type :leaf)
                   |v $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -848,6 +861,7 @@
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482834025) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |p $ {} (:at 1685510453021) (:by |u0) (:text |:some) (:type :leaf)
                               |r $ {} (:at 1632903003605) (:by |u0) (:text |1) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
@@ -855,11 +869,12 @@
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482830585) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510454065) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632902991454) (:by |u0) (:text |1) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482824282) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632903140647) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1632903140647) (:by |u0) (:text |:none) (:type :leaf)
                   |x $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
                       |T $ {} (:at 1632902991454) (:by |u0) (:text |is) (:type :leaf)
@@ -869,6 +884,7 @@
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482835002) (:by |u0) (:text |%maybe) (:type :leaf)
+                              |p $ {} (:at 1685510457966) (:by |u0) (:text |:some) (:type :leaf)
                               |r $ {} (:at 1632903153036) (:by |u0) (:text |2) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
@@ -876,10 +892,11 @@
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482829252) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1632903146186) (:by |u0) (:text |:none) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482825946) (:by |u0) (:text |%maybe) (:type :leaf)
+                                  |p $ {} (:at 1685510459558) (:by |u0) (:text |:some) (:type :leaf)
                                   |r $ {} (:at 1632903149144) (:by |u0) (:text |2) (:type :leaf)
                   |y $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                     :data $ {}
@@ -890,18 +907,18 @@
                           |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |n $ {} (:at 1685482835977) (:by |u0) (:text |%maybe) (:type :leaf)
-                              |r $ {} (:at 1632903160597) (:by |u0) (:text |nil) (:type :leaf)
+                              |r $ {} (:at 1632903160597) (:by |u0) (:text |:none) (:type :leaf)
                           |r $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                             :data $ {}
                               |T $ {} (:at 1632902994374) (:by |u0) (:text |.alt) (:type :leaf)
                               |j $ {} (:at 1632902991454) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482828189) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632903146186) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1632903146186) (:by |u0) (:text |:none) (:type :leaf)
                               |r $ {} (:at 1632902996485) (:by |u0) (:type :expr)
                                 :data $ {}
                                   |n $ {} (:at 1685482827048) (:by |u0) (:text |%maybe) (:type :leaf)
-                                  |r $ {} (:at 1632903157801) (:by |u0) (:text |nil) (:type :leaf)
+                                  |r $ {} (:at 1632903157801) (:by |u0) (:text |:none) (:type :leaf)
         :ns $ {} (:at 1625339956346) (:by |u0) (:type :expr)
           :data $ {}
             |T $ {} (:at 1625339956346) (:by |u0) (:text |ns) (:type :leaf)
@@ -926,6 +943,7 @@
                     |r $ {} (:at 1632902766517) (:by |u0) (:type :expr)
                       :data $ {}
                         |T $ {} (:at 1632902767077) (:by |u0) (:text |maybe-class) (:type :leaf)
+                        |b $ {} (:at 1685505961342) (:by |u0) (:text |%maybe) (:type :leaf)
         :proc $ {} (:at 1625339956346) (:by |u0) (:type :expr)
           :data $ {}
   :users $ {}

--- a/compact.cirru
+++ b/compact.cirru
@@ -40,6 +40,8 @@
       :ns $ quote (ns algebra.maybe)
     |algebra.test $ {}
       :defs $ {}
+        |%maybe $ quote
+          defn %maybe (& args) (%:: maybe-class :maybe & args)
         |animal-class $ quote
           defrecord! animal-class $ :variants
             {}
@@ -102,35 +104,35 @@
         |test-maybe $ quote
           deftest test-maybe
             testing |map
-              is $ = (%:: maybe-class :maybe nil)
-                .map (%:: maybe-class :maybe nil) inc
-              is $ = (%:: maybe-class :maybe 2)
-                .map (%:: maybe-class :maybe 1) inc
+              is $ = (%maybe nil)
+                .map (%maybe nil) inc
+              is $ = (%maybe 2)
+                .map (%maybe 1) inc
             testing "\"bind"
-              is $ = (%:: maybe-class :maybe 2)
-                .bind (%:: maybe-class :maybe 1)
+              is $ = (%maybe 2)
+                .bind (%maybe 1)
                   fn (x)
-                    %:: maybe-class :maybe $ inc x
-              is $ = (%:: maybe-class :maybe nil)
-                .bind (%:: maybe-class :maybe nil)
+                    %maybe $ inc x
+              is $ = (%maybe nil)
+                .bind (%maybe nil)
                   fn (x)
-                    %:: maybe-class :maybe $ inc x
+                    %maybe $ inc x
             testing "\"apply"
-              is $ = (%:: maybe-class :maybe 2)
-                .apply (%:: maybe-class :maybe 1) (%:: maybe-class :maybe inc)
-              is $ = (%:: maybe-class :maybe nil)
-                .apply (%:: maybe-class :maybe nil) (%:: maybe-class :maybe inc)
-              is $ = (%:: maybe-class :maybe nil)
-                .apply (%:: maybe-class :maybe 1) (%:: maybe-class :maybe nil)
+              is $ = (%maybe 2)
+                .apply (%maybe 1) (%maybe inc)
+              is $ = (%maybe nil)
+                .apply (%maybe nil) (%maybe inc)
+              is $ = (%maybe nil)
+                .apply (%maybe 1) (%maybe nil)
             testing "\"alt"
-              is $ = (%:: maybe-class :maybe 1)
-                .alt (%:: maybe-class :maybe 1) (%:: maybe-class :maybe 2)
-              is $ = (%:: maybe-class :maybe 1)
-                .alt (%:: maybe-class :maybe 1) (%:: maybe-class :maybe nil)
-              is $ = (%:: maybe-class :maybe 2)
-                .alt (%:: maybe-class :maybe nil) (%:: maybe-class :maybe 2)
-              is $ = (%:: maybe-class :maybe nil)
-                .alt (%:: maybe-class :maybe nil) (%:: maybe-class :maybe nil)
+              is $ = (%maybe 1)
+                .alt (%maybe 1) (%maybe 2)
+              is $ = (%maybe 1)
+                .alt (%maybe 1) (%maybe nil)
+              is $ = (%maybe 2)
+                .alt (%maybe nil) (%maybe 2)
+              is $ = (%maybe nil)
+                .alt (%maybe nil) (%maybe nil)
       :ns $ quote
         ns algebra.test $ :require
           calcit-test.core :refer $ deftest testing is *quit-on-failure?

--- a/compact.cirru
+++ b/compact.cirru
@@ -4,105 +4,6 @@
     :modules $ [] |calcit-test/
   :entries $ {}
   :files $ {}
-    |algebra.match $ {}
-      :defs $ {}
-        |build-branching $ quote
-          defn build-branching (var0 patterns)
-            if (empty? patterns)
-              quasiquote $ raise (str "\"unreachable in match for " ~var0)
-              &let
-                p0 $ first patterns
-                &let
-                  rule $ nth p0 0
-                  if (= '_ rule)
-                    if
-                      = 1 $ count patterns
-                      nth p0 1
-                      quote $ raise "\"expected `_` at last rule"
-                    quasiquote $ if
-                      = (nth ~var0 0)
-                        ~ $ nth rule 0
-                      ~ $ build-indexed-expr (rest rule) var0 1 (nth p0 1)
-                      ~ $ build-branching var0 (rest patterns)
-        |build-indexed-expr $ quote
-          defn build-indexed-expr (vars var0 idx code)
-            if (empty? vars) code $ if
-              = '_ $ first vars
-              build-indexed-expr (rest vars) var0 (inc idx) code
-              quasiquote $ &let
-                  ~ $ first vars
-                  nth ~var0 ~idx
-                ~ $ build-indexed-expr (rest vars) var0 (inc idx) code
-        |check-definitions $ quote
-          defn check-definitions (rules variants) (; println "\"rules" rules) (; println "\"variants" variants)
-            if (empty? rules)
-              if (empty? variants) true $ raise (str "\"variants not covered:" variants)
-              &let
-                r0 $ first rules
-                if (list? r0)
-                  &let
-                    key $ first r0
-                    assert "\"variant key in keyword" $ keyword? key
-                    if (&map:contains? variants key)
-                      if
-                        = (count r0)
-                          inc $ count (get variants key)
-                        recur (rest rules) (dissoc variants key)
-                        raise $ str "\"invalid size of rule: " r0 "\" " (get variants key)
-                      raise $ str "\"unknown variant:" r0 variants
-                  if (= '_ r0)
-                    if
-                      = 1 $ count rules
-                      if (empty? variants)
-                        raise $ str "\"all variants covered, no need for `_` clause"
-                        , true
-                      raise "\"expected `_` to be tail of patterns"
-        |checked-match $ quote
-          defmacro checked-match (x0 & patterns)
-            &let nil
-              assert "\"pattern in format" $ and (list? patterns)
-              assert "\"check patterns" $ every? (butlast patterns) valid-pattern?
-              assert "\"check last pattern" $ &let
-                t $ last patterns
-                or (valid-last-pattern? t) (valid-pattern? t)
-              &let
-                defined-rules $ map patterns first
-                ; println "\"defs" defined-rules
-                &let
-                  boxed# $ gensym "\"boxed"
-                  &let
-                    var# $ gensym "\"value"
-                    quasiquote $ &let (~boxed# ~x0)
-                      assert "\"expected tuple value" $ tuple? ~boxed#
-                      &let
-                        klass $ nth ~boxed# 0
-                        assert "\"expected class in record" $ record? (nth ~boxed# 0)
-                        assert "\"has variants" $ map? (:variants klass)
-                        assert "\"check all rules defined" $ check-definitions (quote ~defined-rules) (:variants klass)
-                        &let
-                          ~var# $ nth ~boxed# 1
-                          assert "\"expected list for data" $ list? ~var#
-                          if
-                            not $ &map:contains? (:variants klass) (nth ~var# 0)
-                            raise $ str "\"invalid key " (nth ~var# 0) "\" according to " (:variants klass)
-                          ~ $ &let
-                            code $ build-branching var# patterns
-                            ; println $ format-to-lisp code
-                            , code
-        |valid-last-pattern? $ quote
-          defn valid-last-pattern? (xs)
-            and (list? xs)
-              = 2 $ count xs
-              = '_ $ nth xs 0
-        |valid-pattern? $ quote
-          defn valid-pattern? (xs)
-            and (list? xs)
-              = 2 $ count xs
-              &let
-                rule $ nth xs 0
-                and (list? rule)
-                  keyword? $ nth rule 0
-      :ns $ quote (ns algebra.match)
     |algebra.maybe $ {}
       :defs $ {}
         |&alt-maybe $ quote
@@ -155,7 +56,7 @@
           defn main! () $ run-tests
         |match-pet-1 $ quote
           defn match-pet-1 (pet)
-            checked-match pet
+            tag-match pet
                 :cat name color age break-times
                 {} (:name name) (:color color) (:age age) (:bad break-times)
               (:dog name color age)
@@ -164,9 +65,10 @@
                 {} (:name name) (:category category) (:origin origin)
               (:horse name)
                 {} $ :name name
+              _ "\"unknown match result"
         |match-pet-2 $ quote
           defn match-pet-2 (pet)
-            checked-match pet
+            tag-match pet
                 :cat name color age break-times
                 [] "\"Cat" name
               _ "\"not cat"
@@ -183,54 +85,53 @@
           defn test-match () $ do
             testing "\"example 1" $ is
               =
-                match-pet-1 $ :: animal-class ([] :cat "\"Mew" "\"orange" 6 20)
+                match-pet-1 $ %:: animal-class :cat "\"Mew" "\"orange" 6 20
                 {} (:name "\"Mew") (:age 6) (:color "\"orange") (:bad 20)
             testing "\"example 1" $ is
               =
-                match-pet-1 $ :: animal-class ([] :horse "\"Jaky")
+                match-pet-1 $ %:: animal-class :horse "\"Jaky"
                 {} $ :name "\"Jaky"
             testing "\"example 2" $ is
               =
-                match-pet-2 $ :: animal-class ([] :cat "\"Mew" "\"orange" 6 20)
+                match-pet-2 $ %:: animal-class :cat "\"Mew" "\"orange" 6 20
                 [] "\"Cat" "\"Mew"
             testing "\"example 2" $ is
               =
-                match-pet-2 $ :: animal-class ([] :dog "\"Dou" "\"orange" 6)
+                match-pet-2 $ %:: animal-class :dog "\"Dou" "\"orange" 6
                 , "\"not cat"
         |test-maybe $ quote
           deftest test-maybe
             testing |map
-              is $ = (:: maybe-class nil)
-                .map (:: maybe-class nil) inc
-              is $ = (:: maybe-class 2)
-                .map (:: maybe-class 1) inc
+              is $ = (%:: maybe-class :maybe nil)
+                .map (%:: maybe-class :maybe nil) inc
+              is $ = (%:: maybe-class :maybe 2)
+                .map (%:: maybe-class :maybe 1) inc
             testing "\"bind"
-              is $ = (:: maybe-class 2)
-                .bind (:: maybe-class 1)
+              is $ = (%:: maybe-class :maybe 2)
+                .bind (%:: maybe-class :maybe 1)
                   fn (x)
-                    :: maybe-class $ inc x
-              is $ = (:: maybe-class nil)
-                .bind (:: maybe-class nil)
+                    %:: maybe-class :maybe $ inc x
+              is $ = (%:: maybe-class :maybe nil)
+                .bind (%:: maybe-class :maybe nil)
                   fn (x)
-                    :: maybe-class $ inc x
+                    %:: maybe-class :maybe $ inc x
             testing "\"apply"
-              is $ = (:: maybe-class 2)
-                .apply (:: maybe-class 1) (:: maybe-class inc)
-              is $ = (:: maybe-class nil)
-                .apply (:: maybe-class nil) (:: maybe-class inc)
-              is $ = (:: maybe-class nil)
-                .apply (:: maybe-class 1) (:: maybe-class nil)
+              is $ = (%:: maybe-class :maybe 2)
+                .apply (%:: maybe-class :maybe 1) (%:: maybe-class :maybe inc)
+              is $ = (%:: maybe-class :maybe nil)
+                .apply (%:: maybe-class :maybe nil) (%:: maybe-class :maybe inc)
+              is $ = (%:: maybe-class :maybe nil)
+                .apply (%:: maybe-class :maybe 1) (%:: maybe-class :maybe nil)
             testing "\"alt"
-              is $ = (:: maybe-class 1)
-                .alt (:: maybe-class 1) (:: maybe-class 2)
-              is $ = (:: maybe-class 1)
-                .alt (:: maybe-class 1) (:: maybe-class nil)
-              is $ = (:: maybe-class 2)
-                .alt (:: maybe-class nil) (:: maybe-class 2)
-              is $ = (:: maybe-class nil)
-                .alt (:: maybe-class nil) (:: maybe-class nil)
+              is $ = (%:: maybe-class :maybe 1)
+                .alt (%:: maybe-class :maybe 1) (%:: maybe-class :maybe 2)
+              is $ = (%:: maybe-class :maybe 1)
+                .alt (%:: maybe-class :maybe 1) (%:: maybe-class :maybe nil)
+              is $ = (%:: maybe-class :maybe 2)
+                .alt (%:: maybe-class :maybe nil) (%:: maybe-class :maybe 2)
+              is $ = (%:: maybe-class :maybe nil)
+                .alt (%:: maybe-class :maybe nil) (%:: maybe-class :maybe nil)
       :ns $ quote
         ns algebra.test $ :require
           calcit-test.core :refer $ deftest testing is *quit-on-failure?
           algebra.maybe :refer $ maybe-class
-          algebra.match :refer $ checked-match

--- a/package.cirru
+++ b/package.cirru
@@ -1,0 +1,4 @@
+
+{}
+  :dependencies $ {}
+    |calcit-lang/calcit-test |main

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.7.0-a3"
+    "@calcit/procs": "^0.7.0-a5"
   },
   "scripts": {
     "try-js": "mode=ci cr --emit-js -1 && yarn && mode=ci node ./main.mjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "dependencies": {
-    "@calcit/procs": "^0.6.2"
+    "@calcit/procs": "^0.7.0-a3"
   },
   "scripts": {
     "try-js": "mode=ci cr --emit-js -1 && yarn && mode=ci node ./main.mjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,13 +2,13 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.6.2":
-  version "0.6.2"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.6.2.tgz#e350f04ce20e5f698d0ca43a203f77c97102ec1f"
-  integrity sha512-9Ls3GM4SvVpKtPtYJ4Czra7BDq8kEcob9sF6c+c/bFrvgIv7LNAmUTmDGlwp2175WK40zol8ST5Q3QOXnBYCbA==
+"@calcit/procs@^0.7.0-a3":
+  version "0.7.0-a3"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0-a3.tgz#c47c8eb60a07a3188d1cf514af643b821526d00e"
+  integrity sha512-sUJOypiZ0uHVOpE/0vJWAPW/uIMhVe5tWuAxf1NYz6DLC9dHFtUvwOU16oDyMk/bmCnhqcbff8QxHA+EIKL4pw==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
-    "@cirru/parser.ts" "^0.0.5"
+    "@cirru/parser.ts" "^0.0.6"
     "@cirru/writer.ts" "^0.1.3"
 
 "@calcit/ternary-tree@0.0.19":
@@ -16,10 +16,10 @@
   resolved "https://registry.yarnpkg.com/@calcit/ternary-tree/-/ternary-tree-0.0.19.tgz#b5b33a3d07a9e603feeef7cd642958c83628122f"
   integrity sha512-dn2kNlcOQOPtCAeE68MHcRgrZzRP+jNKBmDW2wO0S8HTUA2SeAbpzZoK0HfcTHFmlGl6yKpjZ95rICQ319AjcA==
 
-"@cirru/parser.ts@^0.0.5":
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.5.tgz#12325a69561b95e219e049790c53d5479dc2c1e5"
-  integrity sha512-jmucRW6fQX+HhFZKeN37TDO8ejBxgxLDX9RvU7WKSDM/7peGtfyu9+b6G8NMi4a8wqpDACTvnzbgZId7Xi5bHw==
+"@cirru/parser.ts@^0.0.6":
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/@cirru/parser.ts/-/parser.ts-0.0.6.tgz#b95a84e02273fcbd71ff100925782b6f86410234"
+  integrity sha512-qpDNPq+IuuwYjQFI+wzpd3ntbF7lwJs90v1XWyLQbL9Ru4ld4aHxVGwW/9F/QOu5mEGCMXtagCoYDf0HtOpDZg==
 
 "@cirru/writer.ts@^0.1.3":
   version "0.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,10 +2,10 @@
 # yarn lockfile v1
 
 
-"@calcit/procs@^0.7.0-a3":
-  version "0.7.0-a3"
-  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0-a3.tgz#c47c8eb60a07a3188d1cf514af643b821526d00e"
-  integrity sha512-sUJOypiZ0uHVOpE/0vJWAPW/uIMhVe5tWuAxf1NYz6DLC9dHFtUvwOU16oDyMk/bmCnhqcbff8QxHA+EIKL4pw==
+"@calcit/procs@^0.7.0-a5":
+  version "0.7.0-a5"
+  resolved "https://registry.yarnpkg.com/@calcit/procs/-/procs-0.7.0-a5.tgz#0c38db9c8c2626bbd25c9f36e55d4e7b2cda27f6"
+  integrity sha512-E/3S2MQdoVvI5aHBZxMGP+Yvjk6lj8hWJStMBz93TV34yhteGpnGp2GSeRZsxCgQq/E3N+CXrLQpna0XumKhvQ==
   dependencies:
     "@calcit/ternary-tree" "0.0.19"
     "@cirru/parser.ts" "^0.0.6"


### PR DESCRIPTION
Calcit 0.7 https://github.com/calcit-lang/calcit/pull/208 already provided [`tag-match`](https://apis.calcit-lang.org/?q=tag-match) with is a more solid version of previous `checked-match`. also Calcit has changes in tuple according to https://github.com/calcit-lang/calcit/discussions/209 .
